### PR TITLE
bump version to 3.4.6

### DIFF
--- a/commentpress-core.php
+++ b/commentpress-core.php
@@ -4,7 +4,7 @@ Plugin Name: CommentPress Core
 Plugin URI: http://www.futureofthebook.org/commentpress/
 Description: CommentPress allows readers to comment paragraph by paragraph in the margins of a text. You can use it to annotate, gloss, workshop, debate and more!
 Author: Institute for the Future of the Book
-Version: 3.4.5
+Version: 3.4.6
 Author URI: http://www.futureofthebook.org
 Text Domain: commentpress-core
 --------------------------------------------------------------------------------
@@ -23,7 +23,7 @@ Mark James for the icons: http://www.famfamfam.com/lab/icons/silk/
 // -----------------------------------------------------------------------------
 
 // set version
-define( 'COMMENTPRESS_VERSION', '3.4.5' );
+define( 'COMMENTPRESS_VERSION', '3.4.6' );
 
 // store reference to this file
 if ( !defined( 'COMMENTPRESS_PLUGIN_FILE' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: commentpress, buddypress, groups, blogs, groupblogs, content, comments, commenting, debate, collaboration
 Requires at least: 3.3
 Tested up to: 3.5
-Stable tag: 3.4.5
+Stable tag: 3.4.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
jQuery.ScrollTo now works with WordPress 3.5
