### PR TITLE
Fix some strict standards PHP notices

### DIFF
--- a/commentpress-core/assets/includes/theme/theme-functions.php
+++ b/commentpress-core/assets/includes/theme/theme-functions.php
@@ -12,9 +12,9 @@ NOTES
 
 
 if ( ! function_exists( 'commentpress_admin_header' ) ):
-/** 
+/**
  * @description: custom admin header
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_admin_header() {
@@ -27,16 +27,16 @@ function commentpress_admin_header() {
 
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// override
 		$colour = $commentpress_core->db->option_get_header_bg();
-	
+
 	}
-	
+
 	// try and recreate the look of the theme header
 	echo '
 <style type="text/css">
-    
+
 .appearance_page_custom-header #headimg
 {
 	min-height: 67px;
@@ -50,7 +50,7 @@ function commentpress_admin_header() {
 #headimg #name,
 #headimg #desc
 {
-	margin-left: 20px; 
+	margin-left: 20px;
 	font-family: Helvetica, Arial, sans-serif;
 	font-weight: normal;
 	line-height: 1;
@@ -97,23 +97,23 @@ function commentpress_customize_register( $wp_customize ) {
 
 	// access plugin
 	global $commentpress_core;
-	
+
 	// kick out if buddypress groupblog...
 	if ( is_object( $commentpress_core ) AND $commentpress_core->is_groupblog() ) return;
-	
+
 	// add customizer section title
 	$wp_customize->add_section( 'cp_inline_header_image', array(
 		'title' => __( 'Site Logo', 'commentpress-core' ),
 		'priority' => 35,
 	) );
-	
+
 	// add image
 	$wp_customize->add_setting( 'commentpress_theme_settings[cp_inline_header_image]', array(
 		 'default' => '',
 		 'capability' => 'edit_theme_options',
 		 'type' => 'option'
 	));
-	 
+
 	$wp_customize->add_control( new WP_Customize_Image_Control(
 		$wp_customize, 'cp_inline_header_image', array(
 		'label' => __( 'Logo Image', 'commentpress-core' ),
@@ -121,14 +121,14 @@ function commentpress_customize_register( $wp_customize ) {
 		'settings' => 'commentpress_theme_settings[cp_inline_header_image]',
 		'priority'	=>	1
 	)));
-	
+
 	// add padding
 	$wp_customize->add_setting( 'commentpress_theme_settings[cp_inline_header_padding]', array(
 		 'default' => '',
 		 'capability' => 'edit_theme_options',
 		 'type' => 'option'
 	));
-	 
+
 	$wp_customize->add_control( 'commentpress_theme_settings[cp_inline_header_padding]', array(
 		'label' => __( 'Top padding in px', 'commentpress-core' ),
 		'section' => 'cp_inline_header_image',
@@ -142,7 +142,7 @@ add_action( 'customize_register', 'commentpress_customize_register' );
 
 
 if ( ! function_exists( 'commentpress_admin_menu' ) ) :
-/** 
+/**
  * @description: adds more prominent menu item
  * @todo:
  *
@@ -155,9 +155,9 @@ function commentpress_admin_menu() {
 
 		// add the Customize link to the admin menu
 		add_theme_page( __( 'Customize', 'commentpress-core' ), __( 'Customize', 'commentpress-core' ), 'edit_theme_options', 'customize.php' );
-		
+
 	}
-	
+
 }
 endif; // commentpress_admin_menu
 add_action( 'admin_menu', 'commentpress_admin_menu' );
@@ -165,40 +165,40 @@ add_action( 'admin_menu', 'commentpress_admin_menu' );
 
 
 if ( ! function_exists( 'commentpress_fix_bp_core_avatar_url' ) ):
-/** 
+/**
  * @description: filter to fix broken group avatar images in BP 1.7
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_fix_bp_core_avatar_url( $url ) {
-	
+
 	// if in multisite and on non-root site
 	if ( is_multisite() && !bp_is_root_blog() ) {
-		
+
 		// switch to root site
 		switch_to_blog( bp_get_root_blog_id() );
-		
+
 		// get upload dir data
 		$upload_dir = wp_upload_dir();
-		
+
 		// get storage location of avatars
 		$url = $upload_dir['baseurl'];
-		
+
 		// switch back
 		restore_current_blog();
-		
+
 	}
-	
+
 	// --<
 	return $url;
-	
+
 }
 endif; // commentpress_fix_bp_core_avatar_url
 
 
 
 if ( ! function_exists( 'commentpress_get_header_image' ) ):
-/** 
+/**
  * @description: function that sets a header foreground image (a logo, for example)
  * @todo: inform users that header images are using a different method
  *
@@ -207,63 +207,63 @@ function commentpress_get_header_image() {
 
 	// access plugin
 	global $commentpress_core;
-	
+
 	// -------------------------------------------------------------------------
 	// if this is a groupblog, always show group avatar
 	// -------------------------------------------------------------------------
 
 	// test for groupblog
 	if ( is_object( $commentpress_core ) AND $commentpress_core->is_groupblog() ) {
-	
+
 		// get group ID
 		$group_id = get_groupblog_group_id( get_current_blog_id() );
-	
+
 		// get group avatar
-		$avatar_options = array ( 
-			'item_id' => $group_id, 
-			'object' => 'group', 
-			'type' => 'full', 
-			'alt' => __( 'Group avatar', 'commentpress-core' ), 
-			'class' => 'cp_logo_image cp_group_avatar', 
-			'width' => 48, 
-			'height' => 48, 
-			'html' => true 
+		$avatar_options = array (
+			'item_id' => $group_id,
+			'object' => 'group',
+			'type' => 'full',
+			'alt' => __( 'Group avatar', 'commentpress-core' ),
+			'class' => 'cp_logo_image cp_group_avatar',
+			'width' => 48,
+			'height' => 48,
+			'html' => true
 		);
-		
+
 		//print_r( $avatar_options ); die();
-        
+
 		// add filter for the function above
 		add_filter( 'bp_core_avatar_url', 'commentpress_fix_bp_core_avatar_url', 10, 1 );
-		
+
         // show group avatar
         echo bp_core_fetch_avatar( $avatar_options );
-        
+
         // remove filter
         remove_filter( 'bp_core_avatar_url', 'commentpress_fix_bp_core_avatar_url' );
-		
+
 		// --<
 		return;
-	
+
 	}
-	
+
 	// -------------------------------------------------------------------------
 	// allow plugins to hook in before Theme Customizer
 	// -------------------------------------------------------------------------
 
 	// allow plugins to hook in
 	$custom_avatar_pre = apply_filters( 'commentpress_header_image_pre_customizer', false );
-	
+
 	// did we get one?
 	if ( $custom_avatar_pre !== false ) {
-	
+
 		// show it
 		echo $custom_avatar_pre;
-	
+
 		// bail before fallback
 		return;
 
 	}
-	
+
 	// -------------------------------------------------------------------------
 	// implement compatibility with WordPress Theme Customizer
 	// -------------------------------------------------------------------------
@@ -271,265 +271,265 @@ function commentpress_get_header_image() {
 	// get the new options
 	$options = get_option( 'commentpress_theme_settings' );
 	//print_r( $options ); die();
-	
+
 	// test for our new theme customizer option
 	if ( isset( $options['cp_inline_header_image'] ) AND !empty( $options['cp_inline_header_image'] ) ) {
-	
+
 		// init top padding
 		$style = '';
-		
-		// test for top padding	
+
+		// test for top padding
 		if ( isset( $options['cp_inline_header_padding'] ) AND !empty( $options['cp_inline_header_padding'] ) ) {
-		
+
 			// override
 			$style = ' style="padding-top: '.$options['cp_inline_header_padding'].'px"';
-			
-		}		
-		
+
+		}
+
 		// show the uploaded image
 		echo apply_filters(
 			'commentpress_header_image',
 			'<img src="'.$options['cp_inline_header_image'].'" class="cp_logo_image"'.$style.' alt="'.__( 'Logo', 'commentpress-core' ).'" />'
 		);
-		
+
 		// --<
 		return;
-	
+
 	}
-	
+
 	// -------------------------------------------------------------------------
 	// allow plugins to hook in after Theme Customizer
 	// -------------------------------------------------------------------------
 
 	// allow plugins to hook in
 	$custom_avatar_post = apply_filters( 'commentpress_header_image_post_customizer', false );
-	
+
 	// did we get one?
 	if ( $custom_avatar_post !== false ) {
-	
+
 		// show it
 		echo $custom_avatar_post;
-	
+
 		// bail before fallback
 		return;
 
 	}
-	
+
 	// -------------------------------------------------------------------------
 	// our fallback is to go with the legacy method that some people might still be using
 	// -------------------------------------------------------------------------
 
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) AND $commentpress_core->db->option_get( 'cp_toc_page' ) ) {
-	
+
 		// set defaults
 		$args = array(
-		
+
 			'post_type' => 'attachment',
 			'numberposts' => 1,
 			'post_status' => null,
 			'post_parent' => $commentpress_core->db->option_get( 'cp_toc_page' )
-			
+
 		);
-		
+
 		// get them...
 		$attachments = get_posts( $args );
-		
+
 		// well?
 		if ( $attachments ) {
-		
+
 			// we only want the first
 			$attachment = $attachments[0];
-		
+
 		}
-		
+
 		// if we have an image
-		if ( isset( $attachment ) ) { 
-			
+		if ( isset( $attachment ) ) {
+
 			// show it
 			echo wp_get_attachment_image( $attachment->ID, 'full' );
-						
+
 		}
-		
+
 	}
-	
+
 }
 endif; // commentpress_get_header_image
 
 
 
 if ( ! function_exists( 'commentpress_get_body_id' ) ):
-/** 
+/**
  * @description: get an ID for the body tag
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_get_body_id() {
 
 	// init
 	$_body_id = '';
-	
+
 	// is this multisite?
 	if ( is_multisite() ) {
-	
+
 		// is this the main blog?
 		if ( is_main_site() ) {
-		
+
 			// set main blog id
 			$_body_id = ' id="main_blog"';
-		
+
 		}
-		
+
 	}
-	
+
 	// --<
 	return $_body_id;
-	
+
 }
 endif; // commentpress_get_body_id
 
 
 
 if ( ! function_exists( 'commentpress_get_body_classes' ) ):
-/** 
+/**
  * @description: get classes for the body tag
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_get_body_classes( $raw = false ) {
 
 	// init
 	$_body_classes = '';
-	
+
 	// access post and plugin
 	global $post, $commentpress_core;
-	
+
 	// set default sidebar
 	$sidebar_flag = 'toc';
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// get sidebar
 		$sidebar_flag = $commentpress_core->get_default_sidebar();
-		
+
 	}
-	
+
 	// set class by sidebar
 	$sidebar_class = 'cp_sidebar_'.$sidebar_flag;
-	
+
 	// init commentable class
 	$commentable = '';
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-		
+
 		// set class
 		$commentable = ( $commentpress_core->is_commentable() ) ? ' commentable' : ' not_commentable';
-		
+
 	}
-	
+
 	// init layout class
 	$layout_class = '';
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// is this the title page?
-		if ( 
-			
+		if (
+
 			// be more defensive
 			is_object( $post )
 			AND isset( $post->ID )
-			AND $post->ID == $commentpress_core->db->option_get( 'cp_welcome_page' ) 
-			
+			AND $post->ID == $commentpress_core->db->option_get( 'cp_welcome_page' )
+
 		) {
-		
+
 			// init layout
 			$layout = '';
-			
+
 			// set key
 			$key = '_cp_page_layout';
-			
+
 			// if the custom field already has a value...
 			if ( get_post_meta( $post->ID, $key, true ) != '' ) {
-			
+
 				// get it
 				$layout = get_post_meta( $post->ID, $key, true );
-				
+
 			}
-			
+
 			// if wide layout...
 			if ( $layout == 'wide' ) {
-			
+
 				// set layout class
 				$layout_class = ' full_width';
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
+
 	// set default page type
 	$page_type = '';
-	
+
 	// if blog post...
 	if ( is_single() ) {
-	
+
 		// add blog post class
 		$page_type = ' blog_post';
-		
+
 	}
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// is it a BP special page?
 		if ( $commentpress_core->is_buddypress_special_page() ) {
-	
+
 			// add buddypress page class
 			$page_type = ' buddypress_page';
-		
+
 		}
-		
+
 		// is it a CP special page?
 		if ( $commentpress_core->db->is_special_page() ) {
-	
+
 			// add buddypress page class
 			$page_type = ' commentpress_page';
-		
+
 		}
-		
+
 	}
-	
+
 	// set default type
 	$groupblog_type = ' not-groupblog';
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// if it's a groupblog
 		if ( $commentpress_core->is_groupblog() ) {
 			$groupblog_type = ' is-groupblog';
 		}
-		
+
 	}
-	
+
 	// set default type
 	$blog_type = '';
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// get type
 		$_type = $commentpress_core->db->option_get( 'cp_blog_type' );
 		//print_r( $_type ); die();
-		
+
 		// get workflow
 		$_workflow = $commentpress_core->db->option_get( 'cp_blog_workflow' );
-		
-		// allow plugins to override the blog type - for example if workflow is enabled, 
+
+		// allow plugins to override the blog type - for example if workflow is enabled,
 		// it might be a new blog type as far as buddypress is concerned
 		$_blog_type = apply_filters( 'cp_get_group_meta_for_blog_type', $_type, $_workflow );
 
@@ -537,44 +537,44 @@ function commentpress_get_body_classes( $raw = false ) {
 		if ( is_multisite() AND !is_main_site() ) {
 			$blog_type = ' blogtype-'.intval( $_blog_type );
 		}
-		
+
 	}
-	
+
 	// init TinyMCE class
 	$tinymce_version = ' tinymce-3';
-	
+
 	// access WP version
 	global $wp_version;
 
 	// if greater than 3.8
 	if ( version_compare( $wp_version, '3.8.9999', '>' ) ) {
-	
+
 		// override TinyMCE class
 		$tinymce_version = ' tinymce-4';
-		
+
 	}
-	
+
 	// construct attribute
 	$_body_classes = $sidebar_class.$commentable.$layout_class.$page_type.$groupblog_type.$blog_type.$tinymce_version;
 
 	// if we want them wrapped, do so
 	if ( !$raw ) {
-		
+
 		// preserve backwards compat for older child themes
 		$_body_classes = ' class="'.$_body_classes.'"';
 
 	}
-	
+
 	// --<
 	return $_body_classes;
-	
+
 }
 endif; // commentpress_get_body_classes
 
 
 
 if ( ! function_exists( 'commentpress_site_title' ) ):
-/** 
+/**
  * @description: disable more link jump - from: http://codex.wordpress.org/Customizing_the_Read_More
  * @todo:
  *
@@ -583,55 +583,55 @@ function commentpress_site_title( $sep = '', $echo = true ) {
 
 	// is this multisite?
 	if ( is_multisite() ) {
-	
+
 		// if we're on a sub-blog
 		if ( !is_main_site() ) {
-			
+
 			global $current_site;
-			
+
 			// print?
 			if( $echo ) {
-			
+
 				// add site name
 				echo ' '.trim($sep).' '.$current_site->site_name;
-				
+
 			} else {
-			
+
 				// add site name
 				return ' '.trim($sep).' '.$current_site->site_name;
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
+
 }
 endif; // commentpress_site_title
 
 
 
 if ( ! function_exists( 'commentpress_remove_more_jump_link' ) ):
-/** 
+/**
  * @description: disable more link jump - from: http://codex.wordpress.org/Customizing_the_Read_More
  * @todo:
  *
  */
-function commentpress_remove_more_jump_link( $link ) { 
+function commentpress_remove_more_jump_link( $link ) {
 
 	$offset = strpos($link, '#more-');
-	
+
 	if ($offset) {
 		$end = strpos($link, '"',$offset);
 	}
-	
+
 	if ($end) {
 		$link = substr_replace($link, '', $offset, $end-$offset);
 	}
-	
+
 	// --<
 	return $link;
-	
+
 }
 endif; // commentpress_remove_more_jump_link
 
@@ -641,59 +641,59 @@ add_filter( 'the_content_more_link', 'commentpress_remove_more_jump_link' );
 
 
 if ( ! function_exists( 'commentpress_page_title' ) ):
-/** 
+/**
  * @description: builds a list of previous and next pages, optionally with comments
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_page_title( $with_comments = false ) {
 
 	// declare access to globals
 	global $commentpress_core, $post;
-	
+
 	// init
 	$_title = '';
 	$_sep = ' &#8594; ';
-	
+
 	//$_title .= get_bloginfo('name');
- 
+
 	if ( is_page() OR is_single() OR is_category() ) {
 
 		if (is_page()) {
 
 			$ancestors = get_post_ancestors($post);
- 
+
 			if ($ancestors) {
 				$ancestors = array_reverse($ancestors);
- 				
+
  				$_crumb = array();
- 				
+
 				foreach ($ancestors as $crumb) {
 					$_crumb[] = get_the_title($crumb);
 				}
-				
+
 				$_title .= implode( $_sep, $_crumb ).$_sep;
 			}
 
 		}
- 
+
 		if (is_single()) {
 			//$category = get_the_category();
 			//$_title .= $_sep.$category[0]->cat_name;
 		}
- 
+
 		if (is_category()) {
 			$category = get_the_category();
 			$_title .= $category[0]->cat_name.$_sep;
 		}
- 
+
 		// Current page
 		if (is_page() OR is_single()) {
 			$_title .= get_the_title();
 		}
 
 	}
-	
+
 	// --<
 	return $_title;
 
@@ -703,30 +703,30 @@ endif; // commentpress_page_title
 
 
 if ( ! function_exists( 'commentpress_has_page_children' ) ):
-/** 
+/**
  * @description: query whether a given page has children
- * @todo: 
+ * @todo:
  *
  */
-function commentpress_has_page_children( 
+function commentpress_has_page_children(
 
 	$page_obj
-	
+
 ) { //-->
 
 	// init to look for published pages
-	$defaults = array( 
+	$defaults = array(
 
 		'post_parent' => $page_obj->ID,
-		'post_type' => 'page', 
+		'post_type' => 'page',
 		'numberposts' => -1,
 		'post_status' => 'publish'
 
 	);
-				
+
 	// get page children
 	$kids =& get_children( $defaults );
-	
+
 	// do we have any?
 	return ( empty( $kids ) ) ? false : true;
 
@@ -736,9 +736,9 @@ endif; // commentpress_has_page_children
 
 
 if ( ! function_exists( 'commentpress_get_children' ) ):
-/** 
+/**
  * @description: retrieve comment children
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_get_children( $comment, $page_or_post ) {
@@ -750,13 +750,13 @@ function commentpress_get_children( $comment, $page_or_post ) {
 	$query = "
 	SELECT $wpdb->comments.*, $wpdb->posts.post_title, $wpdb->posts.post_name
 	FROM $wpdb->comments, $wpdb->posts
-	WHERE $wpdb->comments.comment_post_ID = $wpdb->posts.ID 
-	AND $wpdb->posts.post_type = '$page_or_post' 
-	AND $wpdb->comments.comment_approved = '1' 
-	AND $wpdb->comments.comment_parent = '$comment->comment_ID' 
+	WHERE $wpdb->comments.comment_post_ID = $wpdb->posts.ID
+	AND $wpdb->posts.post_type = '$page_or_post'
+	AND $wpdb->comments.comment_approved = '1'
+	AND $wpdb->comments.comment_parent = '$comment->comment_ID'
 	ORDER BY $wpdb->comments.comment_date ASC
 	";
-	
+
 	// does it have children?
 	return $wpdb->get_results( $query );
 
@@ -766,28 +766,28 @@ endif; // commentpress_get_children
 
 
 if ( ! function_exists( 'commentpress_get_comments' ) ):
-/** 
+/**
  * @description: generate comments recursively
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_get_comments( $comments, $page_or_post ) {
 
 	// declare access to globals
 	global $cp_comment_output;
-	
+
 	// do we have any comments?
 	if( count( $comments ) > 0 ) {
-	
+
 		// open ul
 		$cp_comment_output .= '<ul class="item_ul">'."\n\n";
 
 		// produce a checkbox for each
 		foreach( $comments as $comment ) {
-		
+
 			// open li
 			$cp_comment_output .= '<li class="item_li">'."\n\n";
-	
+
 			// format this comment
 			$cp_comment_output .= commentpress_format_comment( $comment );
 
@@ -801,7 +801,7 @@ function commentpress_get_comments( $comments, $page_or_post ) {
 				commentpress_get_comments( $children, $page_or_post );
 
 			}
-			
+
 			// close li
 			$cp_comment_output .= '</li>'."\n\n";
 
@@ -818,184 +818,184 @@ endif; // commentpress_get_comments
 
 
 if ( ! function_exists( 'commentpress_get_user_link' ) ):
-/** 
+/**
  * @description: get user link in vanilla WP scenarios
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_get_user_link( &$user ) {
 
 	/**
-	 * In default single install mode, just link to their URL, unless 
+	 * In default single install mode, just link to their URL, unless
 	 * they are	an author, in which case we link to their author page.
 	 *
 	 * In multisite, the same.
 	 *
 	 * When BuddyPress is enabled, always link to their profile
 	 */
-	
+
 	// kick out if not a user
 	if ( !is_object( $user ) ) { return false; }
-	
+
 	// we're through: the user is on the system
 	global $commentpress_core;
-	
+
 	// if buddypress...
 	if ( is_object( $commentpress_core ) AND $commentpress_core->is_buddypress() ) {
-	
+
 		// buddypress link ($no_anchor = null, $just_link = true)
 		$url = bp_core_get_userlink( $user->ID, null, true );
-		
+
 	} else {
-	
+
 		// get standard WP author url
-	
+
 		// get author url
 		$url = get_author_posts_url( $user->ID );
 		//print_r( $url ); die();
-		
+
 		// WP sometimes leaves 'http://' or 'https://' in the field
 		if (  $url == 'http://'  OR $url == 'https://' ) {
-		
+
 			// clear
 			$url = '';
-		
+
 		}
-		
+
 	}
-	
-	
-	
+
+
+
 	// --<
 	return $url;
-	 
+
 }
 endif; // commentpress_get_user_link
 
 
 
 if ( ! function_exists( 'commentpress_echo_post_meta' ) ):
-/** 
+/**
  * @description: show user(s) in the loop
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_echo_post_meta() {
 
 	// compat with Co-Authors Plus
 	if ( function_exists( 'get_coauthors' ) ) {
-	
+
 		// get multiple authors
 		$authors = get_coauthors();
 		//print_r( $authors ); die();
-		
+
 		// if we get some
 		if ( !empty( $authors ) ) {
-		
+
 			// use the Co-Authors format of "name, name, name & name"
 			$author_html = '';
-			
+
 			// init counter
 			$n = 1;
-			
+
 			// find out how many author we have
 			$author_count = count( $authors );
-		
+
 			// loop
 			foreach( $authors AS $author ) {
-				
+
 				// default to comma
 				$sep = ', ';
-				
+
 				// if we're on the penultimate
 				if ( $n == ($author_count - 1) ) {
-				
+
 					// use ampersand
 					$sep = __( ' &amp; ', 'commentpress-core' );
-					
+
 				}
-				
+
 				// if we're on the last, don't add
 				if ( $n == $author_count ) { $sep = ''; }
-				
+
 				// get name
 				$author_html .= commentpress_echo_post_author( $author->ID, false );
-				
+
 				// and separator
 				$author_html .= $sep;
-				
+
 				// increment
 				$n++;
-				
+
 				// yes - are we showing avatars?
 				if ( get_option('show_avatars') ) {
-				
+
 					// get avatar
 					echo get_avatar( $author->ID, $size='32' );
-					
+
 				}
-					
+
 			}
-			
+
 			?><cite class="fn"><?php echo $author_html; ?></cite>
-			
+
 			<p><a href="<?php the_permalink() ?>"><?php echo esc_html( get_the_date( __( 'l, F jS, Y', 'commentpress-core' ) ) ); ?></a></p>
-			
+
 			<?php
-				
+
 		}
-	
+
 	} else {
-	
+
 		// get avatar
 		$author_id = get_the_author_meta( 'ID' );
 		echo get_avatar( $author_id, $size='32' );
-		
+
 		?>
-		
+
 		<cite class="fn"><?php commentpress_echo_post_author( $author_id ) ?></cite>
-		
+
 		<p><a href="<?php the_permalink() ?>"><?php echo esc_html( get_the_date( __( 'l, F jS, Y', 'commentpress-core' ) ) ); ?></a></p>
-		
-		<?php 
-	
+
+		<?php
+
 	}
-		
+
 }
 endif; // commentpress_echo_post_meta
 
 
 
 if ( ! function_exists( 'commentpress_show_source_url' ) ):
-/** 
+/**
  * @description: show source URL for print
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_show_source_url() {
 
 	// add the URL - hidden, but revealed by print stylesheet
-	?><p class="hidden_page_url"><?php 
-		
+	?><p class="hidden_page_url"><?php
+
 		// label
-		echo __( 'Source: ', 'commentpress-core' ); 
-		
+		echo __( 'Source: ', 'commentpress-core' );
+
 		// path from server array, if set
 		$path = ( isset( $_SERVER['REQUEST_URI'] ) ) ? $_SERVER['REQUEST_URI'] : '';
-		
+
 		// get server, if set
 		$server = ( isset( $_SERVER['SERVER_NAME'] ) ) ? $_SERVER['SERVER_NAME'] : '';
-		
+
 		// get protocol, if set
 		$protocol = ( !empty( $_SERVER['HTTPS'] ) ) ? 'https' : 'http';
-		
+
 		// construct URL
 		$url = $protocol.'://'.$_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];
-		
+
 		// echo
 		echo $url;
-		
-	?></p><?php 
+
+	?></p><?php
 
 }
 endif; // commentpress_show_source_url
@@ -1006,30 +1006,30 @@ add_action( 'wp_footer', 'commentpress_show_source_url' );
 
 
 if ( ! function_exists( 'commentpress_echo_post_author' ) ):
-/** 
+/**
  * Show username (with link) in the loop
- * @todo: 
+ * @todo:
  *
  */
 function commentpress_echo_post_author( $author_id, $echo = true ) {
 
 	// get author details
 	$user = get_userdata( $author_id );
-	
+
 	// kick out if we don't have a user with that ID
 	if ( !is_object( $user ) ) { return; }
-	
+
 	// access plugin
 	global $commentpress_core, $post;
 
 	// if we have the plugin enabled and it's BP
 	if ( is_object( $post ) AND is_object( $commentpress_core ) AND $commentpress_core->is_buddypress() ) {
-	
+
 		// construct user link
 		$author = bp_core_get_userlink( $user->ID );
 
 	} else {
-	
+
 		// link to theme's author page
 		$link = sprintf(
 			'<a href="%1$s" title="%2$s" rel="author">%3$s</a>',
@@ -1040,21 +1040,21 @@ function commentpress_echo_post_author( $author_id, $echo = true ) {
 		$author = apply_filters( 'the_author_posts_link', $link );
 
 	}
-	
+
 	// if we're echoing
-	if ( $echo ) { 
+	if ( $echo ) {
 		echo $author;
 	} else {
 		return $author;
 	}
-		
+
 }
 endif; // commentpress_echo_post_author
 
 
 
 if ( ! function_exists( 'commentpress_format_comment' ) ):
-/** 
+/**
  * Format comment on custom CommentPress comments pages
  */
 function commentpress_format_comment( $comment, $context = 'all' ) {
@@ -1064,70 +1064,70 @@ function commentpress_format_comment( $comment, $context = 'all' ) {
 
 	// enable Wordpress API on comment
 	//$GLOBALS['comment'] = $comment;
-	
+
 	// construct link
 	$_comment_link = get_comment_link( $comment->comment_ID );
-	
+
 	// construct anchor
 	$_comment_anchor = '<a href="'.$_comment_link.'" title="'.esc_attr( __( 'See comment in context', 'commentpress-core' ) ).'">'.__( 'Comment', 'commentpress-core' ).'</a>';
-	
+
 	// construct date
 	$_comment_date = date( __( 'F jS, Y', 'commentpress-core' ), strtotime( $comment->comment_date ) );
-	
+
 	// if context is 'all comments'...
 	if ( $context == 'all' ) {
-	
+
 		// get author
 		if ( $comment->comment_author != '' ) {
-		
+
 			// was it a registered user?
 			if ( $comment->user_id != '0' ) {
-			
+
 				// get user details
 				$user = get_userdata( $comment->user_id );
 				//print_r( $user->display_name ); die();
-				
+
 				// get user link
 				$user_link = commentpress_get_user_link( $user );
-				
+
 				// did we get one?
 				if ( $user_link != '' AND $user_link != 'http://' ) {
-				
+
 					// construct link to user url
 					$_comment_author = '<a href="'.$user_link.'">'.$comment->comment_author.'</a>';
-					
+
 				} else {
-				
+
 					// just show author name
 					$_comment_author = $comment->comment_author;
-				
+
 				}
-				
+
 			} else {
-			
+
 				// do we have an author URL?
 				if ( $comment->comment_author_url != '' AND $comment->comment_author_url != 'http://' ) {
-				
+
 					// construct link to user url
 					$_comment_author = '<a href="'.$comment->comment_author_url.'">'.$comment->comment_author.'</a>';
-					
+
 				} else {
-				
+
 					// define context
 					$_comment_author = $comment->comment_author;
-				
+
 				}
-				
+
 			}
-			
-			
-		} else { 
-		
+
+
+		} else {
+
 			// we don't have a name
 			$_comment_author = __( 'Anonymous', 'commentpress-core' );
-			
+
 		}
-	
+
 		// construct comment header content
 		$_comment_meta_content = sprintf(
 			__( '%1$s by %2$s on %3$s', 'commentpress-core' ),
@@ -1135,12 +1135,12 @@ function commentpress_format_comment( $comment, $context = 'all' ) {
 			$_comment_author,
 			$_comment_date
 		);
-		
+
 		// wrap comment meta in a div
 		$_comment_meta = '<div class="comment_meta">'.$_comment_meta_content.'</div>'."\n";
-	
+
 		// allow filtering by plugins
-		$_comment_meta = apply_filters( 
+		$_comment_meta = apply_filters(
 			'commentpress_format_comment_all_meta', // filter name
 			$_comment_meta, // built meta
 			$comment,
@@ -1148,16 +1148,16 @@ function commentpress_format_comment( $comment, $context = 'all' ) {
 			$_comment_author,
 			$_comment_date
 		);
-		
+
 	// if context is 'by commenter'
 	} elseif ( $context == 'by' ) {
-	
+
 		// construct link
 		$_page_link = trailingslashit( get_permalink( $comment->comment_post_ID ) );
-		
+
 		// construct page anchor
 		$_page_anchor = '<a href="'.$_page_link.'">'.get_the_title( $comment->comment_post_ID ).'</a>';
-	
+
 		// construct comment header content
 		$_comment_meta_content = sprintf(
 			__( '%1$s on %2$s on %3$s', 'commentpress-core' ),
@@ -1168,9 +1168,9 @@ function commentpress_format_comment( $comment, $context = 'all' ) {
 
 		// wrap comment meta in a div
 		$_comment_meta = '<div class="comment_meta">'.$_comment_meta_content.'</div>'."\n";
-	
+
 		// allow filtering by plugins
-		$_comment_meta = apply_filters( 
+		$_comment_meta = apply_filters(
 			'commentpress_format_comment_by_meta', // filter name
 			$_comment_meta, // built meta
 			$comment,
@@ -1178,22 +1178,22 @@ function commentpress_format_comment( $comment, $context = 'all' ) {
 			$_page_anchor,
 			$_comment_date
 		);
-	
+
 	}
-	
+
 	// comment content
 	$_comment_body = '<div class="comment-content">'.apply_filters( 'comment_text', $comment->comment_content ).'</div>'."\n";
-	
+
 	// construct comment
 	return '<div class="comment_wrapper">'."\n".$_comment_meta.$_comment_body.'</div>'."\n\n";
-	
+
 }
 endif; // commentpress_format_comment
 
 
 
 if ( ! function_exists( 'commentpress_get_comments_by_content' ) ):
-/** 
+/**
  * Comments-by page display function
  *
  * @todo: do we want trackbacks?
@@ -1212,24 +1212,24 @@ function commentpress_get_comments_by_content() {
 		'order' => 'ASC',
 	) );
 	//print_r( $all_comments ); //die();
-	
+
 	// kick out if none
 	if ( count( $all_comments ) == 0 ) return $html;
-	
+
 	// build list of authors
 	$authors_with = array();
 	$author_names = array();
 	//$post_comment_counts = array();
 
 	foreach( $all_comments AS $comment ) {
-		
+
 		// add to authors with comments array
 		if ( !in_array( $comment->comment_author_email, $authors_with ) ) {
 			$authors_with[] = $comment->comment_author_email;
 			$name = $comment->comment_author != '' ? $comment->comment_author : __( 'Anonymous', 'commentpress-core' );
 			$author_names[$comment->comment_author_email] = $name;
 		}
-		
+
 		/*
 		// increment counter
 		if ( !isset( $post_comment_counts[$comment->comment_author_email] ) ) {
@@ -1238,75 +1238,75 @@ function commentpress_get_comments_by_content() {
 			$post_comment_counts[$comment->comment_author_email]++;
 		}
 		*/
-		
+
 	}
 	//print_r( $post_comment_counts ); //die();
 	//print_r( $authors_with ); die();
-	
+
 	// kick out if none
 	if ( count( $authors_with ) == 0 ) return $html;
-	
+
 	// open ul
 	$html .= '<ul class="all_comments_listing">'."\n\n";
-	
+
 	// loop through authors
 	foreach( $authors_with AS $author ) {
-		
+
 		// open li
 		$html .= '<li class="author_li"><!-- author li -->'."\n\n";
-		
+
 		// add gravatar
 		$html .= '<h3>'.get_avatar( $author, $size='24' ). esc_html( $author_names[$author] ).'</h3>'."\n\n";
 
 		// open comments div
 		$html .= '<div class="item_body">'."\n\n";
-		
+
 		// open ul
 		$html .= '<ul class="item_ul">'."\n\n";
 
 		// loop through comments
 		foreach( $all_comments AS $comment ) {
-			
+
 			// does it belong to this author?
 			if ( $author == $comment->comment_author_email ) {
-		
+
 				// open li
 				$html .= '<li class="item_li"><!-- item li -->'."\n\n";
-	
+
 				// show the comment
 				$html .= commentpress_format_comment( $comment, 'by' );
-		
+
 				// close li
 				$html .= '</li><!-- /item li -->'."\n\n";
 
 			}
 
 		}
-	
+
 		// close ul
 		$html .= '</ul>'."\n\n";
-		
+
 		// close item div
 		$html .= '</div><!-- /item_body -->'."\n\n";
-		
+
 		// close li
 		$html .= '</li><!-- /.author_li -->'."\n\n\n\n";
-		
+
 	}
-	
+
 	// close ul
 	$html .= '</ul><!-- /.all_comments_listing -->'."\n\n";
-	
+
 	// --<
 	return $html;
-	
+
 }
 endif; // commentpress_get_comments_by_content
 
 
 
 if ( ! function_exists( 'commentpress_get_comments_by_page_content' ) ):
-/** 
+/**
  * Comments-by page display function
  *
  * @return str $_page_content The page content
@@ -1318,26 +1318,26 @@ function commentpress_get_comments_by_page_content() {
 	if ( $wp_embed instanceof WP_Embed ) {
 		add_filter( 'comment_text', array( $wp_embed, 'autoembed' ), 1 );
 	}
-	
+
 	// declare access to globals
 	global $commentpress_core;
-	
+
 	// set title
 	$_page_content = '<h2 class="post_title">'.__( 'Comments by Commenter', 'commentpress-core' ).'</h2>'."\n\n";
 
 	// get data
 	$_page_content .= commentpress_get_comments_by_content();
-	
+
 	// --<
 	return $_page_content;
-	
+
 }
 endif; // commentpress_get_comments_by_page_content
 
 
 
 if ( ! function_exists( 'commentpress_show_activity_tab' ) ):
-/** 
+/**
  * Decide whether or not to show the Activity Sidebar
  *
  * @return bool True if we show the activity tab, false otherwise
@@ -1346,39 +1346,39 @@ function commentpress_show_activity_tab() {
 
 	// declare access to globals
 	global $commentpress_core, $post;
-	
+
 	/*
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// is this multisite?
-		if ( 
-		
-			( is_multisite() 
-			AND is_main_site() 
+		if (
+
+			( is_multisite()
+			AND is_main_site()
 			AND $commentpress_core->is_buddypress_special_page() )
 			OR !is_object( $post )
-			
+
 		) {
-		
+
 			// ignore activity
 			return false;
-			
+
 		}
-		
+
 	}
 	*/
-	
+
 	// --<
 	return true;
-	
+
 }
 endif; // commentpress_show_activity_tab
 
 
 
 if ( ! function_exists( 'commentpress_is_commentable' ) ):
-/** 
+/**
  * Is a post/page commentable?
  *
  * @return bool $is_commentable True if page can have comments, false otherwise
@@ -1387,25 +1387,25 @@ function commentpress_is_commentable() {
 
 	// declare access to plugin
 	global $commentpress_core;
-	
+
 	// if we have it...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// return what it reports
 		return $commentpress_core->is_commentable();
-		
+
 	}
-	
+
 	// --<
 	return false;
-	
+
 }
 endif; // commentpress_is_commentable
 
 
 
 if ( ! function_exists( 'commentpress_get_comment_activity' ) ):
-/** 
+/**
  * Activity sidebar display function
  * @todo: do we want trackbacks?
  *
@@ -1418,192 +1418,192 @@ function commentpress_get_comment_activity( $scope = 'all' ) {
 	if ( $wp_embed instanceof WP_Embed ) {
 		add_filter( 'comment_text', array( $wp_embed, 'autoembed' ), 1 );
 	}
-	
+
 	// declare access to globals
 	global $commentpress_core, $post;
 
 	// init page content
 	$_page_content = '';
-	
+
 	// define defaults
 	$args = array(
-	
+
 		'number' => 10,
 		'status' => 'approve',
-		
+
 		// exclude trackbacks and pingbacks until we decide what to do with them
-		'type' => '' 
-	
+		'type' => ''
+
 	);
-	
+
 	// if we are on a 404, for example
 	if ( $scope == 'post' AND is_object( $post ) ) {
-	
+
 		// get all comments
 		$args['post_id'] = $post->ID;
 
 	}
-	
+
 	// get 'em
 	$_data = get_comments( $args );
 	//print_r( $_data ); exit();
-	
+
 	// did we get any?
 	if ( count( $_data ) > 0 ) {
-		
+
 		// open ul
 		$_page_content .= '<ol class="comment_activity">'."\n\n";
-		
+
 		// init title
 		$_title = '';
-		
+
 		// loop
 		foreach ($_data as $comment) {
-			
+
 			// exclude comments from password-protected posts
 			if ( ! post_password_required( $comment->comment_post_ID ) ) {
 				$_page_content .= commentpress_get_comment_activity_item( $comment );
 			}
-		
+
 		}
-	
+
 		// close ul
 		$_page_content .= '</ol><!-- /comment_activity -->'."\n\n";
-	
+
 	}
-	
+
 	// --<
 	return $_page_content;
-	
+
 }
 endif; // commentpress_get_comment_activity
 
 
 
 if ( ! function_exists( 'commentpress_get_comment_activity_item' ) ):
-/** 
+/**
  * Get comment formatted for the activity sidebar
  *
  * @param $comment The comment object
  * @return $item_html The modified comment HTML
  */
 function commentpress_get_comment_activity_item( $comment ) {
-	
+
 	// enable Wordpress API on comment
 	$GLOBALS['comment'] = $comment;
-	
+
 	// declare access to globals
 	global $commentpress_core, $post;
 
 	// init markup
 	$item_html = '';
-	
+
 	// only comments until we decide what to do with pingbacks
 	if ( $comment->comment_type == 'pingback' ) { return $item_html; }
-	
+
 	// test for anonymous comment (usually generated by WP itself in multisite installs)
 	if ( empty( $comment->comment_author ) ) {
-	
+
 		$comment->comment_author = __( 'Anonymous', 'commentpress-core' );
-	
+
 	}
-	
+
 	// was it a registered user?
 	if ( $comment->user_id != '0' ) {
-	
+
 		// get user details
 		$user = get_userdata( $comment->user_id );
 		//print_r( $user->display_name ); die();
-		
+
 		// get user link
 		$user_link = commentpress_get_user_link( $user );
-		
+
 		// construct author citation
 		$author = '<cite class="fn"><a href="'.$user_link.'">'.esc_html( $comment->comment_author ).'</a></cite>';
-		
+
 		// construct link to user url
-		$author = ( $user_link != '' AND $user_link != 'http://' ) ? 
-					'<cite class="fn"><a href="'.$user_link.'">'.esc_html( $comment->comment_author ).'</a></cite>' : 
+		$author = ( $user_link != '' AND $user_link != 'http://' ) ?
+					'<cite class="fn"><a href="'.$user_link.'">'.esc_html( $comment->comment_author ).'</a></cite>' :
 					 '<cite class="fn">'.esc_html( $comment->comment_author ).'</cite>';
-		
+
 	} else {
-	
+
 		// construct link to commenter url
-		$author = ( $comment->comment_author_url != '' AND $comment->comment_author_url != 'http://' ) ? 
-					'<cite class="fn"><a href="'.$comment->comment_author_url.'">'.esc_html( $comment->comment_author ).'</a></cite>' : 
+		$author = ( $comment->comment_author_url != '' AND $comment->comment_author_url != 'http://' ) ?
+					'<cite class="fn"><a href="'.$comment->comment_author_url.'">'.esc_html( $comment->comment_author ).'</a></cite>' :
 					 '<cite class="fn">'.esc_html( $comment->comment_author ).'</cite>';
-	
+
 	}
-	
+
 	// approved comment?
 	if ($comment->comment_approved == '0') {
 		$comment_text = '<p><em>'.__( 'Comment awaiting moderation', 'commentpress-core' ).'</em></p>';
 	} else {
 		$comment_text = get_comment_text( $comment->comment_ID );
 	}
-	
+
 	// default to not on post
 	$is_on_current_post = '';
 
 	// on current post?
 	if ( is_singular() AND is_object( $post ) AND $comment->comment_post_ID == $post->ID ) {
-		
+
 		// access paging globals
 		global $multipage, $page;
-		
+
 		// is it the same page, if paged?
 		if ( $multipage ) {
-			
+
 			/*
-			print_r( array( 
-				'multipage' => $multipage, 
-				'page' => $page 
+			print_r( array(
+				'multipage' => $multipage,
+				'page' => $page
 			) ); die();
 			*/
-			
+
 			// if it has a text sig
-			if ( 
-			
-				!is_null( $comment->comment_signature ) 
-				AND $comment->comment_signature != '' 
-				
+			if (
+
+				!is_null( $comment->comment_signature )
+				AND $comment->comment_signature != ''
+
 			) {
 
 				// set key
 				$key = '_cp_comment_page';
-				
+
 				// if the custom field already has a value...
 				if ( get_comment_meta( $comment->comment_ID, $key, true ) != '' ) {
-				
+
 					// get comment's page from meta
 					$page_num = get_comment_meta( $comment->comment_ID, $key, true );
-					
+
 					// is it this one?
 					if ( $page_num == $page ) {
-					
+
 						// is the right page
 						$is_on_current_post = ' comment_on_post';
-					
+
 					}
-					
+
 				}
-			
+
 			} else {
-			
+
 				// it's always the right page for page-level comments
 				$is_on_current_post = ' comment_on_post';
-			
+
 			}
-			
+
 		} else {
-			
+
 			// must be the right page
 			$is_on_current_post = ' comment_on_post';
-		
+
 		}
-		
+
 	}
-	
+
 	// open li
 	$item_html .= '<li><!-- item li -->'."\n\n";
 
@@ -1613,7 +1613,7 @@ function commentpress_get_comment_activity_item( $comment ) {
 
 <div class="comment-identifier">
 '.get_avatar( $comment, $size='32' ).'
-'.$author.'		
+'.$author.'
 <p class="comment_activity_date"><a class="comment_activity_link'.$is_on_current_post.'" href="'.htmlspecialchars( get_comment_link() ).'">'. sprintf( __( '%1$s at %2$s', 'commentpress-core' ), get_comment_date(), get_comment_time() ).'</a></p>
 </div><!-- /comment-identifier -->
 
@@ -1631,318 +1631,318 @@ function commentpress_get_comment_activity_item( $comment ) {
 
 	// close li
 	$item_html .= '</li><!-- /item li -->'."\n\n";
-	
+
 	// --<
 	return $item_html;
-	
+
 }
 endif; // commentpress_get_comment_activity_item
 
 
 
 if ( ! function_exists( 'commentpress_get_comments_by_para' ) ):
-/** 
+/**
  * @description: get comments delimited by paragraph
  * @todo: translation
  *
  */
 function commentpress_get_comments_by_para() {
-	
+
 	// allow oEmbed in comments
 	global $wp_embed;
 	if ( $wp_embed instanceof WP_Embed ) {
 		add_filter( 'comment_text', array( $wp_embed, 'autoembed' ), 1 );
 	}
-	
+
 	// allow plugins to precede comments
 	do_action( 'commentpress_before_scrollable_comments' );
-	
+
 	// declare access to globals
 	global $post, $commentpress_core;
-	
+
 	// get approved comments for this post, sorted comments by text signature
 	$comments_sorted = $commentpress_core->get_sorted_comments( $post->ID );
 	//print_r( $comments_sorted ); die();
-	
+
 	// get text signatures
 	//$text_sigs = $commentpress_core->db->get_text_sigs();
 
 	// init starting paragraph number
 	$start_num = 1;
-	
+
 	// set key
 	$key = '_cp_starting_para_number';
-	
+
 	// if the custom field already has a value...
 	if ( get_post_meta( $post->ID, $key, true ) != '' ) {
-	
+
 		// get it
 		$start_num = absint( get_post_meta( $post->ID, $key, true ) );
-		
+
 	}
-	
+
 	// if we have any...
 	if ( count( $comments_sorted ) > 0 ) {
-	
+
 		// construct redirect link
 		$redirect = site_url( 'wp-login.php?redirect_to='.get_permalink() );
-		
+
 		// init allowed to comment
 		$login_to_comment = false;
-		
+
 		// if we have to log in to comment...
 		if ( get_option('comment_registration') AND !is_user_logged_in() ) {
 			$login_to_comment = true;
 		}
-		
+
 		// default comment type to get
 		$comment_type = 'all';
 
 		// if we don't allow pingbacks...
 		if ( !('open' == $post->ping_status) ) {
-		
+
 			// just get comments
 			$comment_type = 'comment';
-	
+
 		}
-		
+
 		// check for a WP 3.8+ function
 		if ( function_exists( 'wp_admin_bar_sidebar_toggle' ) ) {
-		
+
 			// Walker_Comment has changed to buffered output, so define args without
 			// our custom walker. The built in walker works just fine now.
 			$args = array(
-			
+
 				// list comments params
-				'style'=> 'ol', 
-				'type'=> $comment_type, 
+				'style'=> 'ol',
+				'type'=> $comment_type,
 				'callback' => 'commentpress_comments'
-			
+
 			);
-			
+
 		} else {
 
-			// init new walker, because the original class did not include the option 
+			// init new walker, because the original class did not include the option
 			// of using ordered lists <ol> instead of unordered ones <ul>
 			// @see https://github.com/WordPress/WordPress/blob/5828310157f1805a5f0976d76692c7023e8a895d/wp-includes/comment-template.php#L880
 			$walker = new Walker_Comment_Press;
-		
+
 			// define args
 			$args = array(
-			
+
 				// list comments params
 				'walker' => $walker,
-				'style'=> 'ol', 
-				'type'=> $comment_type, 
+				'style'=> 'ol',
+				'type'=> $comment_type,
 				'callback' => 'commentpress_comments'
-			
+
 			);
-			
+
 		}
-		
+
 		// init counter for text_signatures array
 		$sig_counter = 0;
-		
+
 		// init array for tracking text sigs
 		$used_text_sigs = array();
-		
+
 		// loop through each paragraph
 		foreach( $comments_sorted AS $text_signature => $_comments ) {
-		
+
 			// count comments
 			$comment_count = count( $_comments );
-			
+
 			// switch, depending on key
 			switch( $text_signature ) {
-				
+
 				// whole page comments
 				case 'WHOLE_PAGE_OR_POST_COMMENTS':
 
 					// clear text signature
 					$text_sig = '';
-					
+
 					// clear the paragraph number
 					$para_num = '';
-					
+
 					// define default phrase
 					$paragraph_text = __( 'the whole page', 'commentpress-core' );
-					
+
 					$current_type = get_post_type();
 					//print_r( $current_type ); die();
-					
+
 					switch( $current_type ) {
-						
+
 						// we can add more of these if needed
 						case 'post': $paragraph_text = __( 'the whole post', 'commentpress-core' ); break;
 						case 'page': $paragraph_text = __( 'the whole page', 'commentpress-core' ); break;
-						
+
 					}
-				
+
 					// set permalink text
 					$permalink_text = sprintf(
 						__('Permalink for comments on %s', 'commentpress-core' ),
 						$paragraph_text
 					);
-					
+
 					// define heading text
 					$heading_text = sprintf( _n(
-						
+
 						// singular
-						'<span class="cp_comment_num">%d</span> <span class="cp_comment_word">Comment</span> on ', 
-						
+						'<span class="cp_comment_num">%d</span> <span class="cp_comment_word">Comment</span> on ',
+
 						// plural
-						'<span class="cp_comment_num">%d</span> <span class="cp_comment_word">Comments</span> on ', 
-						
+						'<span class="cp_comment_num">%d</span> <span class="cp_comment_word">Comments</span> on ',
+
 						// number
-						$comment_count, 
-						
+						$comment_count,
+
 						// domain
 						'commentpress-core'
-					
+
 					// substitution
 					), $comment_count );
-					
+
 					// append para text
 					$heading_text .= '<span class="source_block">'.$paragraph_text.'</span>';
-					
+
 					break;
-				
+
 				// pingbacks etc
 				case 'PINGS_AND_TRACKS':
 
 					// set "unique-enough" text signature
 					$text_sig = 'pingbacksandtrackbacks';
-					
+
 					// clear the paragraph number
 					$para_num = '';
-					
+
 					// define heading text
 					$heading_text = sprintf( _n(
-						
+
 						// singular
-						'<span>%d</span> Pingback or trackback', 
-						
+						'<span>%d</span> Pingback or trackback',
+
 						// plural
-						'<span>%d</span> Pingbacks and trackbacks', 
-						
+						'<span>%d</span> Pingbacks and trackbacks',
+
 						// number
-						$comment_count, 
-						
+						$comment_count,
+
 						// domain
 						'commentpress-core'
-					
+
 					// substitution
 					), $comment_count );
-					
+
 					// set permalink text
 					$permalink_text = __( 'Permalink for pingbacks and trackbacks', 'commentpress-core' );
-					
+
 					// wrap in span
 					$heading_text = '<span>'.$heading_text.'</span>';
 
 					break;
-					
+
 				// textblock comments
 				default:
 
 					// get text signature
 					$text_sig = $text_signature;
-				
+
 					// paragraph number
 					$para_num = $sig_counter + ( $start_num - 1 );
-					
+
 					// which parsing method?
 					if ( defined( 'COMMENTPRESS_BLOCK' ) ) {
-					
+
 						switch ( COMMENTPRESS_BLOCK ) {
-						
+
 							case 'tag' :
-								
+
 								// set block identifier
 								$block_name = __( 'paragraph', 'commentpress-core' );
-							
+
 								break;
-								
+
 							case 'block' :
-								
+
 								// set block identifier
 								$block_name = __( 'block', 'commentpress-core' );
-							
+
 								break;
-								
+
 							case 'line' :
-								
+
 								// set block identifier
 								$block_name = __( 'line', 'commentpress-core' );
-							
+
 								break;
-								
+
 						}
-					
+
 					} else {
-					
+
 						// set block identifier
 						$block_name = __( 'paragraph', 'commentpress-core' );
-					
+
 					}
-					
+
 					// set paragraph text
 					$paragraph_text = $block_name.' '.$para_num;
-					
+
 					// set permalink text
 					$permalink_text = sprintf(
 						__('Permalink for comments on %s', 'commentpress-core' ),
 						$paragraph_text
 					);
-					
+
 					// define heading text
 					$heading_text = sprintf( _n(
-						
+
 						// singular
-						'<span class="cp_comment_num">%d</span> <span class="cp_comment_word">Comment</span> on ', 
-						
+						'<span class="cp_comment_num">%d</span> <span class="cp_comment_word">Comment</span> on ',
+
 						// plural
-						'<span class="cp_comment_num">%d</span> <span class="cp_comment_word">Comments</span> on ', 
-						
+						'<span class="cp_comment_num">%d</span> <span class="cp_comment_word">Comments</span> on ',
+
 						// number
-						$comment_count, 
-						
+						$comment_count,
+
 						// domain
 						'commentpress-core'
-					
+
 					// substitution
 					), $comment_count );
-					
+
 					// append para text
 					$heading_text .= '<span class="source_block">'.$paragraph_text.'</span>';
-					
+
 			} // end switch
-			
+
 			// init no comment class
 			$no_comments_class = '';
-			
+
 			// override if there are no comments (for print stylesheet to hide them)
 			if ( $comment_count == 0 ) { $no_comments_class = ' class="no_comments"'; }
-			
+
 			// eclude pings if there are none
 			if ( $comment_count == 0 AND $text_signature == 'PINGS_AND_TRACKS' ) {
-			
+
 				// skip
-				
+
 			} else {
-			
+
 				// show heading
 				echo '<h3 id="para_heading-'.$text_sig.'"'.$no_comments_class.'><a class="comment_block_permalink" title="'.$permalink_text.'" href="#para_heading-'.$text_sig.'">'.$heading_text.'</a></h3>'."\n\n";
-	
+
 				// override if there are no comments (for print stylesheet to hide them)
 				if ( $comment_count == 0 ) { $no_comments_class = ' no_comments'; }
-				
+
 				// open paragraph wrapper
 				echo '<div id="para_wrapper-'.$text_sig.'" class="paragraph_wrapper'.$no_comments_class.'">'."\n\n";
-	
+
 				// have we already used this text signature?
 				if( in_array( $text_sig, $used_text_sigs ) ) {
-				
+
 					// show some kind of message
 					// should not be necessary now that we ensure unique text sigs
 					echo '<div class="reply_to_para" id="reply_to_para-'.$para_num.'">'."\n".
@@ -1950,106 +1950,106 @@ function commentpress_get_comments_by_para() {
 								__( 'It appears that this paragraph is a duplicate of a previous one.', 'commentpress-core' ).
 							'</p>'."\n".
 						 '</div>'."\n\n";
-	
+
 				} else {
-			
+
 					// if we have comments...
 					if ( count( $_comments ) > 0 ) {
-					
+
 						// open commentlist
 						echo '<ol class="commentlist">'."\n\n";
-				
+
 						// use WP 2.7+ functionality
-						wp_list_comments( $args, $_comments ); 
-						
+						wp_list_comments( $args, $_comments );
+
 						// close commentlist
 						echo '</ol>'."\n\n";
-							
+
 					}
-					
+
 					// add to used array
 					$used_text_sigs[] = $text_sig;
-				
+
 					// only add comment-on-para link if comments are open and it's not the pingback section
 					if ( 'open' == $post->comment_status AND $text_signature != 'PINGS_AND_TRACKS' ) {
-					
+
 						// if we have to log in to comment...
 						if ( $login_to_comment ) {
-						
+
 							// leave comment link
 							echo '<div class="reply_to_para" id="reply_to_para-'.$para_num.'">'."\n".
 									'<p><a class="reply_to_para" rel="nofollow" href="'.$redirect.'">'.
 										__( 'Login to leave a comment on ', 'commentpress-core' ).$paragraph_text.
 									'</a></p>'."\n".
 								 '</div>'."\n\n";
-							
+
 						} else {
-						
+
 							// construct onclick content
 							$onclick = "return addComment.moveFormToPara( '$para_num', '$text_sig', '$post->ID' )";
-							
+
 							// construct onclick attribute
-							$onclick = apply_filters( 
+							$onclick = apply_filters(
 								'commentpress_reply_to_para_link_onclick',
 								' onclick="'.$onclick.'"'
 							);
-						
+
 							// just show replytopara
-							$query = remove_query_arg( array( 'replytocom' ) ); 
-			
+							$query = remove_query_arg( array( 'replytocom' ) );
+
 							// add param to querystring
-							$query = esc_attr( 
-								add_query_arg( 
+							$query = esc_attr(
+								add_query_arg(
 									array( 'replytopara' => $para_num ),
 									$query
 								)
 							);
-							
+
 							// construct href attribute
-							$href = apply_filters( 
+							$href = apply_filters(
 								'commentpress_reply_to_para_link_href',
 								$query.'#respond', // add respond ID
 								$text_sig
 							);
-						
+
 							// construct link content
 							$link_content = sprintf(
 								__( 'Leave a comment on %s', 'commentpress-core' ),
 								$paragraph_text
 							);
-						
+
 							// allow overrides
-							$link_content = apply_filters( 
+							$link_content = apply_filters(
 								'commentpress_reply_to_para_link_text',
 								$link_content,
 								$paragraph_text
 							);
-							
+
 							// leave comment link
 							echo '<div class="reply_to_para" id="reply_to_para-'.$para_num.'">'."\n".
 									'<p><a class="reply_to_para" href="'.$href.'"'.$onclick.'>'.
 										$link_content.
 									'</a></p>'."\n".
 								 '</div>'."\n\n";
-							
+
 						}
-							 
+
 					}
-						 
+
 				}
-	
+
 				// close paragraph wrapper
 				echo '</div>'."\n\n\n\n";
-				
+
 			}
-			
+
 			// increment signature array counter
 			$sig_counter++;
-			
+
 		}
-		
+
 	}
-	
+
 }
 endif; // commentpress_get_comments_by_para
 
@@ -2077,26 +2077,26 @@ class Walker_Comment_Press extends Walker_Comment {
 		if( $depth === 0 ) {
 			//echo '<h3>New Top Level</h3>'."\n";
 		}
-		
+
 		// store depth
 		$GLOBALS['comment_depth'] = $depth + 1;
-		
+
 		// open children if necessary
 		switch ( $args['style'] ) {
-		
+
 			case 'div':
 				break;
-				
+
 			case 'ol':
 				echo '<ol class="children">'."\n";
 				break;
-				
+
 			default:
 			case 'ul':
 				echo '<ul class="children">'."\n";
 				break;
 		}
-		
+
 	}
 
 }
@@ -2104,7 +2104,7 @@ class Walker_Comment_Press extends Walker_Comment {
 
 
 if ( ! function_exists( 'commentpress_comment_form_title' ) ):
-/** 
+/**
  * Alternative to the built-in WP function
  *
  * @param str $no_reply_text
@@ -2113,92 +2113,92 @@ if ( ! function_exists( 'commentpress_comment_form_title' ) ):
  * @param str $link_to_parent
  * @return void
  */
-function commentpress_comment_form_title( 
-	
-	$no_reply_text = '', 
-	$reply_to_comment_text = '', 
-	$reply_to_para_text = '', 
-	$link_to_parent = TRUE 
-	
+function commentpress_comment_form_title(
+
+	$no_reply_text = '',
+	$reply_to_comment_text = '',
+	$reply_to_para_text = '',
+	$link_to_parent = TRUE
+
 ) {
-	
+
 	// sanity checks
 	if ( $no_reply_text == '' ) { $no_reply_text = __( 'Leave a Reply', 'commentpress-core' ); }
 	if ( $reply_to_comment_text == '' ) { $reply_to_comment_text = __( 'Leave a Reply to %s', 'commentpress-core' ); }
 	if ( $reply_to_para_text == '' ) { $reply_to_para_text = __( 'Leave a Comment on %s', 'commentpress-core' ); }
-	
+
 	// declare access to globals
 	global $comment, $commentpress_core;
-	
+
 	// get comment ID to reply to from URL query string
 	$reply_to_comment_id = isset($_GET['replytocom']) ? (int) $_GET['replytocom'] : 0;
 
 	// get paragraph number to reply to from URL query string
 	$reply_to_para_id = isset($_GET['replytopara']) ? (int) $_GET['replytopara'] : 0;
-	
+
 	// if we have no comment ID AND no paragraph ID to reply to
 	if ( $reply_to_comment_id == 0 AND $reply_to_para_id == 0 ) {
-		
+
 		// write default title to page
 		echo $no_reply_text;
-		
+
 	} else {
-	
+
 		// if we have a comment ID AND NO paragraph ID to reply to
 		if ( $reply_to_comment_id != 0 AND $reply_to_para_id == 0 ) {
-	
+
 			// get comment
 			$comment = get_comment( $reply_to_comment_id );
-			
+
 			// get link to comment
-			$author = ( $link_to_parent ) ? 
-				'<a href="#comment-' . get_comment_ID() . '">' . get_comment_author() . '</a>' : 
+			$author = ( $link_to_parent ) ?
+				'<a href="#comment-' . get_comment_ID() . '">' . get_comment_author() . '</a>' :
 				get_comment_author();
-			
+
 			// write to page
 			printf( $reply_to_comment_text, $author );
-			
+
 		} else {
-		
+
 			// get paragraph text signature
 			$text_sig = $commentpress_core->get_text_signature( $reply_to_para_id );
-		
+
 			// get link to paragraph
 			if ( $link_to_parent ) {
-				
+
 				// construct link text
 				$para_text = sprintf(
 					__( 'Paragraph %s', 'commentpress-core' ),
 					$reply_to_para_id
 				);
-				
+
 				// construct paragraph
 				$paragraph = '<a href="#para_heading-' . $text_sig . '">'.$para_text.'</a>';
-				
+
 			} else {
-			
+
 				// construct paragraph without link
 				$paragraph = sprintf(
 					__( 'Paragraph %s', 'commentpress-core' ),
 					$para_num
 				);
-			
+
 			}
-			
+
 			// write to page
 			printf( $reply_to_para_text, $paragraph );
-			
+
 		}
-	
+
 	}
-	
+
 }
 endif; // commentpress_comment_form_title
 
 
 
 if ( ! function_exists( 'commentpress_comment_reply_link' ) ):
-/** 
+/**
  * Alternative to the built-in WP function
  *
  * @param array $args The reply links arguments
@@ -2206,78 +2206,78 @@ if ( ! function_exists( 'commentpress_comment_reply_link' ) ):
  * @param object $post The post
  */
 function commentpress_comment_reply_link( $args = array(), $comment = null, $post = null ) {
-	
+
 	// set some defaults
 	$defaults = array(
-	
-		'add_below' => 'comment', 
-		'respond_id' => 'respond', 
+
+		'add_below' => 'comment',
+		'respond_id' => 'respond',
 		'reply_text' => __( 'Reply', 'commentpress-core' ),
-		'login_text' => __( 'Log in to Reply', 'commentpress-core' ), 
-		'depth' => 0, 
-		'before' => '', 
+		'login_text' => __( 'Log in to Reply', 'commentpress-core' ),
+		'depth' => 0,
+		'before' => '',
 		'after' => ''
-		
+
 	);
-	
+
 	// parse them
 	$args = wp_parse_args($args, $defaults);
 
 	if ( 0 == $args['depth'] || $args['max_depth'] <= $args['depth'] ) {
 		return;
 	}
-	
+
 	// convert to vars
 	extract($args, EXTR_SKIP);
-	
+
 	// get the obvious
 	$comment = get_comment($comment);
 	$post = get_post($post);
 
 	// kick out if comments closed
 	if ( 'open' != $post->comment_status ) { return false; }
-	
+
 	// init link
 	$link = '';
-	
+
 	// if we have to log in to comment...
 	if ( get_option( 'comment_registration' ) AND !is_user_logged_in() ) {
-		
+
 		// construct link
 		$link = '<a rel="nofollow" href="' . site_url('wp-login.php?redirect_to=' . get_permalink()) . '">' . $login_text . '</a>';
-		
+
 	} else {
-	
+
 		// just show replytocom
-		$query = remove_query_arg( array( 'replytopara' ), get_permalink( $post->ID ) ); 
+		$query = remove_query_arg( array( 'replytopara' ), get_permalink( $post->ID ) );
 
 		// define query string
-		$addquery = esc_html( 
-		
-			add_query_arg( 
-			
+		$addquery = esc_html(
+
+			add_query_arg(
+
 				array( 'replytocom' => $comment->comment_ID ),
 				$query
-				
-			) 
-			
+
+			)
+
 		);
-		
+
 		// define link
 		$link = "<a rel='nofollow' class='comment-reply-link' href='" . $addquery . "#" . $respond_id . "' onclick='return addComment.moveForm(\"$add_below-$comment->comment_ID\", \"$comment->comment_ID\", \"$respond_id\", \"$post->ID\", \"$comment->comment_signature\")'>$reply_text</a>";
-		
+
 	}
-	
+
 	// --<
 	return apply_filters( 'comment_reply_link', $before . $link . $after, $args, $comment, $post );
-	
+
 }
 endif; // commentpress_comment_reply_link
 
 
 
 if ( ! function_exists( 'commentpress_comments' ) ):
-/** 
+/**
  * Custom comments display function
  *
  * @param object $comment The comment object
@@ -2289,14 +2289,14 @@ function commentpress_comments( $comment, $args, $depth ) {
 
 	// build comment as html
 	echo commentpress_get_comment_markup( $comment, $args, $depth );
-	
+
 }
 endif; // commentpress_comments
 
 
 
 if ( ! function_exists( 'commentpress_get_comment_markup' ) ):
-/** 
+/**
  * Wrap comment in its markup
  *
  * @param object $comment The comment object
@@ -2316,33 +2316,33 @@ function commentpress_get_comment_markup( $comment, $args, $depth ) {
 
 	// was it a registered user?
 	if ( $comment->user_id != '0' ) {
-	
+
 		// get user details
 		$user = get_userdata( $comment->user_id );
 		//print_r( $user->display_name ); die();
-		
+
 		// get user link
 		$user_link = commentpress_get_user_link( $user );
 		//print_r( array( 'u' => $user_link ) ); die();
-		
+
 		// construct author citation
-		$author = ( $user_link != '' AND $user_link != 'http://' ) ? 
-					'<cite class="fn"><a href="'.$user_link.'">'.get_comment_author().'</a></cite>' : 
+		$author = ( $user_link != '' AND $user_link != 'http://' ) ?
+					'<cite class="fn"><a href="'.$user_link.'">'.get_comment_author().'</a></cite>' :
 					 '<cite class="fn">'.get_comment_author().'</cite>';
-		
+
 		//print_r( array( 'a' => $author ) ); die();
 
 	} else {
-	
+
 		// construct link to commenter url
-		$author = ( $comment->comment_author_url != '' AND $comment->comment_author_url != 'http://' AND $comment->comment_approved != '0' ) ? 
-					'<cite class="fn"><a href="'.$comment->comment_author_url.'">'.get_comment_author().'</a></cite>' : 
+		$author = ( $comment->comment_author_url != '' AND $comment->comment_author_url != 'http://' AND $comment->comment_approved != '0' ) ?
+					'<cite class="fn"><a href="'.$comment->comment_author_url.'">'.get_comment_author().'</a></cite>' :
 					 '<cite class="fn">'.get_comment_author().'</cite>';
-	
+
 	}
-		
-	
-	
+
+
+
 	/*
 	if ($comment->comment_approved == '0') {
 		$author = '<cite class="fn">'.get_comment_author().'</cite>';
@@ -2350,9 +2350,9 @@ function commentpress_get_comment_markup( $comment, $args, $depth ) {
 		$author = '<cite class="fn">'.get_comment_author_link().'</cite>';
 	}
 	*/
-	
-	
-	
+
+
+
 	if ( $comment->comment_approved == '0' ) {
 		$comment_text = '<p><em>'.__( 'Comment awaiting moderation', 'commentpress-core' ).'</em></p>';
 	} else {
@@ -2360,101 +2360,101 @@ function commentpress_get_comment_markup( $comment, $args, $depth ) {
 	}
 
 
-	
+
 	// empty reply div by default
 	$comment_reply = '';
 
 	// enable access to post
 	global $post;
-	
+
 	// can we reply?
-	if ( 
-		
+	if (
+
 		// not if comments are closed
-		$post->comment_status == 'open' 
-		
+		$post->comment_status == 'open'
+
 		// we don't want reply to on pingbacks
-		AND $comment->comment_type != 'pingback' 
-		
+		AND $comment->comment_type != 'pingback'
+
 		// nor on unapproved comments
-		AND $comment->comment_approved == '1' 
-		
+		AND $comment->comment_approved == '1'
+
 	) {
-	
+
 		// are we threading comments?
 		if ( get_option( 'thread_comments', false ) ) {
-		
+
 			// custom comment_reply_link
 			$comment_reply = commentpress_comment_reply_link(
-			
+
 				array_merge(
-				
-					$args, 
+
+					$args,
 					array(
 						'reply_text' => sprintf( __( 'Reply to %s', 'commentpress-core' ), get_comment_author() ),
-						'depth' => $depth, 
+						'depth' => $depth,
 						'max_depth' => $args['max_depth']
 					)
 				)
-				
+
 			);
-			
+
 			// wrap in div
 			$comment_reply = '<div class="reply">'.$comment_reply.'</div><!-- /reply -->';
-			
+
 		}
-		
+
 	}
-	
-	
-	
+
+
+
 	// init edit link
 	$editlink = '';
-	
+
 	// if logged in and has capability
-	if ( 
-		is_user_logged_in() 
-	AND 
-		current_user_can('edit_posts') 
-	AND 
-		current_user_can( 'edit_comment', $comment->comment_ID ) 
+	if (
+		is_user_logged_in()
+	AND
+		current_user_can('edit_posts')
+	AND
+		current_user_can( 'edit_comment', $comment->comment_ID )
 	) {
-	
+
 		// set default edit link title text
-		$edit_title_text = apply_filters( 
-			'cp_comment_edit_link_title_text', 
+		$edit_title_text = apply_filters(
+			'cp_comment_edit_link_title_text',
 			__( 'Edit this comment', 'commentpress-core' )
 		);
-	
+
 		// set default edit link text
-		$edit_text = apply_filters( 
-			'cp_comment_edit_link_text', 
+		$edit_text = apply_filters(
+			'cp_comment_edit_link_text',
 			__( 'Edit', 'commentpress-core' )
 		);
-	
+
 		// get edit comment link
 		$editlink = '<span class="alignright comment-edit"><a class="comment-edit-link" href="'.get_edit_comment_link().'" title="'.$edit_title_text.'">'.$edit_text.'</a></span>';
-		
+
 		// add a filter for plugins
 		$editlink = apply_filters( 'cp_comment_edit_link', $editlink, $comment );
-		
+
 	}
-	
+
 	// add a nopriv filter for plugins
 	$editlink = apply_filters( 'cp_comment_action_links', $editlink, $comment );
-	
-	
-	
+
+
+
 	// get comment class(es)
 	$_comment_class = comment_class( null, $comment->comment_ID, $post->ID, false );
-	
+
 	// if orphaned, add class to identify as such
 	$_comment_orphan = ( isset( $comment->orphan ) ) ? ' comment-orphan' : '';
-	
-	
-	
+
+
+
 	// stripped source
-	$html = '	
+	$html = '
 <li id="li-comment-'.$comment->comment_ID.'" '.$_comment_class.'>
 <div class="comment-wrapper">
 <div id="comment-'.$comment->comment_ID.'">
@@ -2464,7 +2464,7 @@ function commentpress_get_comment_markup( $comment, $args, $depth ) {
 <div class="comment-identifier'.$_comment_orphan.'">
 '.get_avatar( $comment, $size='32' ).'
 '.$editlink.'
-'.$author.'		
+'.$author.'
 <a class="comment_permalink" href="'.htmlspecialchars( get_comment_link() ).'">'.get_comment_date().' at '.get_comment_time().'</a>
 </div><!-- /comment-identifier -->
 
@@ -2488,14 +2488,14 @@ function commentpress_get_comment_markup( $comment, $args, $depth ) {
 
 	// --<
 	return $html;
-	
+
 }
 endif; // commentpress_get_comment_markup
 
 
 
 if ( ! function_exists( 'commentpress_get_full_name' ) ):
-/** 
+/**
  * Utility to concatenate names
  *
  * @param str $forename The WordPress user's first name
@@ -2506,26 +2506,26 @@ function commentpress_get_full_name( $forename, $surname ) {
 
 	// init return
 	$fullname = '';
-	
+
 	// add forename
-	if ($forename != '' ) { $fullname .= $forename; } 
-	
+	if ($forename != '' ) { $fullname .= $forename; }
+
 	// add surname
 	if ($surname != '' ) { $fullname .= ' ' . $surname; }
-	
+
 	// strip any whitespace
 	$fullname = trim( $fullname );
-	
+
 	// --<
 	return $fullname;
-	
+
 }
 endif; // commentpress_get_full_name
 
 
 
 if ( ! function_exists( 'commentpress_excerpt_length' ) ):
-/** 
+/**
  * Utility to define length of excerpt
  *
  * @return int $length The length of the excerpt
@@ -2534,21 +2534,21 @@ function commentpress_excerpt_length() {
 
 	// declare access to globals
 	global $commentpress_core;
-	
+
 	// is the plugin active?
 	if ( !is_object( $commentpress_core ) ) {
-	
+
 		// --<
 		return 55; // Wordpress default
-		
+
 	}
-	
+
 	// get length of excerpt from option
 	$length = $commentpress_core->db->option_get( 'cp_excerpt_length' );
-	
+
 	// --<
 	return $length;
-	
+
 }
 endif; // commentpress_excerpt_length
 
@@ -2558,7 +2558,7 @@ add_filter( 'excerpt_length', 'commentpress_excerpt_length' );
 
 
 if ( ! function_exists( 'commentpress_add_link_css' ) ):
-/** 
+/**
  * Utility to add button css class to blog nav links
  *
  * @param str $link The existing link
@@ -2571,7 +2571,7 @@ function commentpress_add_link_css( $link ) {
 
 	// --<
 	return $link;
-	
+
 }
 endif; // commentpress_add_link_css
 
@@ -2582,7 +2582,7 @@ add_filter( 'next_post_link', 'commentpress_add_link_css' );
 
 
 if ( ! function_exists( 'commentpress_get_link_css' ) ):
-/** 
+/**
  * Utility to add button css class to blog nav links
  *
  * @return str $link The custom class attribute
@@ -2594,7 +2594,7 @@ function commentpress_get_link_css() {
 
 	// --<
 	return $link;
-	
+
 }
 endif; // commentpress_get_link_css
 
@@ -2605,7 +2605,7 @@ add_filter( 'next_posts_link_attributes', 'commentpress_get_link_css' );
 
 
 if ( ! function_exists( 'commentpress_multipage_comment_link' ) ):
-/** 
+/**
  * Filter comment permalinks for multipage posts
  *
  * @param str $link The existing comment link
@@ -2617,35 +2617,35 @@ function commentpress_multipage_comment_link( $link, $comment, $args ) {
 
 	// get multipage and post
 	global $multipage, $post;
-	
+
 	// are there multiple (sub)pages?
 	//if ( is_object( $post ) AND $multipage ) {
-	
+
 		// exclude page level comments
 		if ( $comment->comment_signature != '' ) {
-		
+
 			// init page num
 			$page_num = 1;
-		
+
 			// set key
 			$key = '_cp_comment_page';
-			
+
 			// if the custom field already has a value...
 			if ( get_comment_meta( $comment->comment_ID, $key, true ) != '' ) {
-			
+
 				// get the page number
 				$page_num = get_comment_meta( $comment->comment_ID, $key, true );
-				
+
 			}
-			
+
 			// get current comment info
 			$comment_path_info = parse_url( $link );
-			
+
 			// set comment path
 			return commentpress_get_post_multipage_url( $page_num, get_post( $comment->comment_post_ID ) ).'#'.$comment_path_info['fragment'];
 
 		}
-		
+
 	//}
 
 	// --<
@@ -2668,10 +2668,10 @@ function commentpress_get_post_multipage_url( $i, $post = '' ) {
 
 	// if we have no passed value
 	if ( $post == '' ) {
-		
+
 		// we assume we're in the loop
 		global $post, $wp_rewrite;
-	
+
 		if ( 1 == $i ) {
 			$url = get_permalink();
 		} else {
@@ -2682,9 +2682,9 @@ function commentpress_get_post_multipage_url( $i, $post = '' ) {
 			else
 				$url = trailingslashit(get_permalink()) . user_trailingslashit($i, 'single_paged');
 		}
-		
+
 	} else {
-		
+
 		// use passed post object
 		if ( 1 == $i ) {
 			$url = get_permalink( $post->ID );
@@ -2696,17 +2696,17 @@ function commentpress_get_post_multipage_url( $i, $post = '' ) {
 			else
 				$url = trailingslashit(get_permalink( $post->ID )) . user_trailingslashit($i, 'single_paged');
 		}
-		
+
 	}
-	
+
 	return esc_url( $url );
-	
+
 }
 
 
 
 if ( ! function_exists( 'commentpress_multipager' ) ):
-/** 
+/**
  * Create sane links between pages
  *
  * @return str $page_links The next page and previous page links
@@ -2716,43 +2716,43 @@ function commentpress_multipager() {
 
 	// set default behaviour
 	$defaults = array(
-		
+
 		'before' => '<div class="multipager">',
 		'after' => '</div>',
-		'link_before' => '', 
+		'link_before' => '',
 		'link_after' => '',
-		'next_or_number' => 'next', 
+		'next_or_number' => 'next',
 		'nextpagelink' => '<span class="alignright">'.__( 'Next page', 'commentpress-core' ).' &raquo;</span>',
 		'previouspagelink' => '<span class="alignleft">&laquo; '.__( 'Previous page', 'commentpress-core' ).'</span>',
 		'pagelink' => '%',
-		'more_file' => '', 
+		'more_file' => '',
 		'echo' => 0
-		
+
 	);
-	
+
 	// get page links
 	$page_links = wp_link_pages( $defaults );
 	//print_r( $page_links ); die();
-	
+
 	// add separator when there are two links
-	$page_links = str_replace( 
-	
-		'a><a', 
-		'a> <span class="multipager_sep">|</span> <a', 
-		$page_links 
-		
+	$page_links = str_replace(
+
+		'a><a',
+		'a> <span class="multipager_sep">|</span> <a',
+		$page_links
+
 	);
-	
+
 	// get page links
 	$page_links .= wp_link_pages( array(
-	
-		'before' => '<div class="multipager multipager_all"><span>' . __( 'Pages: ', 'commentpress-core' ) . '</span>', 
+
+		'before' => '<div class="multipager multipager_all"><span>' . __( 'Pages: ', 'commentpress-core' ) . '</span>',
 		'after' => '</div>',
 		'pagelink' => '<span class="multipager_link">%</span>',
-		'echo' => 0 
-		
+		'echo' => 0
+
 	) );
-	
+
 	// --<
 	return $page_links;
 
@@ -2768,61 +2768,61 @@ endif; // commentpress_multipager
  * @return str $mce_css The list of stylesheets with ours added
  */
 function commentpress_add_wp_editor() {
-	
+
 	// init option
 	$rich_text = false;
-	
+
 	global $commentpress_core;
-	
+
 	// kick out if wp_editor doesn't exist
 	// TinyMCE will be handled by including the script using the pre- wp_editor() method
 	if ( !function_exists( 'wp_editor' ) ) {
-	
+
 		// --<
 		return false;
-	
+
 	}
 
 	// kick out if plugin not active
 	if ( !is_object( $commentpress_core ) ) {
-	
+
 		// --<
 		return false;
-	
+
 	}
 
 	// only allow through if plugin says so
 	if ( !$commentpress_core->display->is_tinymce_allowed() ) {
-	
+
 		// --<
 		return false;
 
 	}
-	
+
 	// add our buttons
-	$mce_buttons = apply_filters( 
-		
+	$mce_buttons = apply_filters(
+
 		// filter for plugins
-		'cp_tinymce_buttons', 
-		
+		'cp_tinymce_buttons',
+
 		// basic buttons
 		array(
-			'bold', 
-			'italic', 
-			'underline', 
+			'bold',
+			'italic',
+			'underline',
 			'|',
 			'bullist',
 			'numlist',
 			'|',
-			'link', 
-			'unlink', 
-			'|', 
+			'link',
+			'unlink',
+			'|',
 			'removeformat',
 			'fullscreen'
 		)
-		
+
 	);
-	
+
 	// allow media buttons setting to be overridden
 	$media_buttons = apply_filters( 'commentpress_rte_media_buttons', true );
 
@@ -2831,31 +2831,31 @@ function commentpress_add_wp_editor() {
 
 	// if greater than 3.8
 	if ( version_compare( $wp_version, '3.8.9999', '>' ) ) {
-	
+
 		// TinyMCE 4 - allow tinymce config to be overridden
-		$tinymce_config = apply_filters( 
-			'commentpress_rte_tinymce', 
+		$tinymce_config = apply_filters(
+			'commentpress_rte_tinymce',
 			array(
 				'theme' => 'modern',
 				'statusbar' => false,
 			)
 		);
-		
+
 		// no need for editor css
 		$editor_css = '';
-	
+
 	} else {
-	
+
 		// TinyMCE 3 - allow tinymce config to be overridden
-		$tinymce_config = apply_filters( 
-			'commentpress_rte_tinymce', 
+		$tinymce_config = apply_filters(
+			'commentpress_rte_tinymce',
 			array(
 				'theme' => 'advanced',
 				'theme_advanced_buttons1' => implode( ',', $mce_buttons ),
 				'theme_advanced_statusbar_location' => 'none',
 			)
 		);
-		
+
 		// use legacy editor css
 		$editor_css = '
 			<style type="text/css">
@@ -2865,48 +2865,48 @@ function commentpress_add_wp_editor() {
 				}
 			</style>
 		';
-	
+
 	}
-	
+
 	// allow quicktags setting to be overridden
-	$quicktags = apply_filters( 
-		'commentpress_rte_quicktags', 
+	$quicktags = apply_filters(
+		'commentpress_rte_quicktags',
 		array(
 			'buttons' => 'strong,em,ul,ol,li,link,close'
 		)
 	);
-	
+
 	// our settings
 	$settings = array(
-		
+
 		// configure comment textarea
 		'media_buttons' => $media_buttons,
 		'textarea_name' => 'comment',
 		'textarea_rows' => 10,
-		
+
 		// might as well start with teeny
 		'teeny' => true,
-		
+
 		// give the iframe a white background
 		'editor_css' => $editor_css,
-		
+
 		// configure TinyMCE
 		'tinymce' => $tinymce_config,
-		
+
 		// configure quicktags
 		'quicktags' => $quicktags
-	
+
 	);
-	
+
 	// create editor
 	wp_editor(
-	
+
 		'', // initial content
 		'comment', // id of comment textarea
 		$settings
-	
+
 	);
-	
+
 	// don't show textarea
 	return true;
 
@@ -2924,12 +2924,12 @@ function commentpress_assign_default_editor( $r ) {
 
 	// only on front-end
 	if ( is_admin() ) { return $r; }
-	
+
 	// always return 'tinymce' as the default editor, or else the comment form will not show up!
-	
+
 	// --<
 	return 'tinymce';
-	
+
 }
 
 add_filter( 'wp_default_editor', 'commentpress_assign_default_editor', 10, 1 );
@@ -2946,16 +2946,16 @@ function commentpress_add_tinymce_styles( $mce_css ) {
 
 	// only on front-end
 	if ( is_admin() ) { return $mce_css; }
-	
+
 	// add comma if not empty
 	if ( !empty( $mce_css ) ) { $mce_css .= ','; }
-	
+
 	// add our editor styles
 	$mce_css .= get_template_directory_uri().'/assets/css/comment-form.css';
-	
+
 	// --<
 	return $mce_css;
-	
+
 }
 
 // add filter for the above
@@ -2970,27 +2970,27 @@ add_filter( 'mce_css', 'commentpress_add_tinymce_styles' );
  * @return array $buttons The buttons with More removed
  */
 function commentpress_add_tinymce_nextpage_button( $buttons ) {
-	
+
 	// only on back-end
 	if ( !is_admin() ) { return $buttons; }
-	
+
 	// try and place Next Page after More button
 	$pos = array_search( 'wp_more', $buttons, true );
-	
+
 	// is it there?
 	if ($pos !== false) {
-	
+
 		// get array up to that point
 		$tmp_buttons = array_slice( $buttons, 0, $pos + 1 );
-		
+
 		// add Next Page button
 		$tmp_buttons[] = 'wp_page';
-		
+
 		// recombine
 		$buttons = array_merge( $tmp_buttons, array_slice( $buttons, $pos + 1 ) );
-		
+
 	}
-	
+
 	// --<
 	return $buttons;
 
@@ -3011,16 +3011,16 @@ function commentpress_assign_editor_buttons( $buttons ) {
 
 	// basic buttons
 	return array(
-		'bold', 
-		'italic', 
-		'underline', 
+		'bold',
+		'italic',
+		'underline',
 		'|',
 		'bullist',
 		'numlist',
 		'|',
-		'link', 
-		'unlink', 
-		'|', 
+		'link',
+		'unlink',
+		'|',
 		'removeformat',
 		'fullscreen'
 	);
@@ -3038,7 +3038,7 @@ if ( version_compare( $wp_version, '3.8.9999', '>' ) ) {
 
 
 if ( ! function_exists( 'commentpress_comment_post_redirect' ) ):
-/** 
+/**
  * Filter comment post redirects for multipage posts
  *
  * @param str $link The link to the comment
@@ -3048,43 +3048,43 @@ function commentpress_comment_post_redirect( $link, $comment ) {
 
 	// get URL of the page that submitted the comment
 	$page_url = $_SERVER['HTTP_REFERER'];
-	
+
 	// get anchor position
 	$hash = strpos( $page_url, '#' );
 
 	// well, do we have an anchor?
 	if ( $hash !== false ) {
-		
+
 		// yup, so strip it
 		$page_url = substr( $page_url, 0, $hash );
-	
+
 	}
 
 	// assume not AJAX
 	$ajax_token = '';
-	
+
 	// is this an AJAX comment form submission?
 	if ( isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) ) {
 		if ( $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest' ) {
 
 			// yes, it's AJAX - some browsers cache POST, so invalidate
 			$ajax_token = '?cachebuster='.time();
-			
+
 			// but, test for pretty permalinks
 			if ( false !== strpos( $page_url, '?' ) ) {
-		
+
 				// pretty permalinks are off...
 				$ajax_token = '&cachebuster='.time();
-		
+
 			}
-	
+
 		}
-		
+
 	}
 
 	// construct cachebusting comment redirect
 	$link = $page_url.$ajax_token.'#comment-'.$comment->comment_ID;
-	
+
 	// --<
 	return $link;
 
@@ -3097,7 +3097,7 @@ add_filter( 'comment_post_redirect', 'commentpress_comment_post_redirect', 4, 2 
 
 
 if ( ! function_exists( 'commentpress_image_caption_shortcode' ) ):
-/** 
+/**
  * Rebuild caption shortcode output
  *
  * @param array $empty WordPress passes '' as the first param!
@@ -3106,7 +3106,7 @@ if ( ! function_exists( 'commentpress_image_caption_shortcode' ) ):
  * @return str $_caption The modified caption
  */
 function commentpress_image_caption_shortcode( $empty = null, $attr, $content ) {
-	
+
 	// get our shortcode vars
 	extract(shortcode_atts(array(
 		'id'	=> '',
@@ -3114,41 +3114,41 @@ function commentpress_image_caption_shortcode( $empty = null, $attr, $content ) 
 		'width'	=> '',
 		'caption' => ''
 	), $attr));
-	
+
 	/*
 	print_r( array(
 		'content' => $content,
 		'caption' => $caption,
 	) ); die();
 	*/
-	
+
 	if ( 1 > (int) $width || empty($caption) )
 		return $content;
-	
+
 	// sanitise id
 	if ( $id ) $id = 'id="' . esc_attr($id) . '" ';
-	
+
 	// add space prior to alignment
 	$_alignment = ' '.esc_attr($align);
-	
+
 	// get width
 	$_width = (0 + (int) $width);
-	
+
 	// sanitise caption
 	$caption = wp_kses( $caption,
-		
+
 		// allow a few tags
 		array(
-			'em' => array(),  
-			'strong' => array(),  
+			'em' => array(),
+			'strong' => array(),
 			'a' => array('href')
 		)
-		
+
 	);
-	
+
 	// force balance those tags
 	$caption = balanceTags( $caption, true );
-	
+
 	// construct
 	$_caption = '<!-- cp_caption_start -->'.
 				'<span class="captioned_image'.$_alignment.'" style="width: '.$_width.'px">'.
@@ -3156,10 +3156,10 @@ function commentpress_image_caption_shortcode( $empty = null, $attr, $content ) 
 					'<small class="wp-caption-text">'.$caption.'</small>'.
 				'</span>'.
 				'<!-- cp_caption_end -->';
-	
+
 	// --<
 	return $_caption;
-	
+
 }
 endif; // commentpress_image_caption_shortcode
 
@@ -3169,7 +3169,7 @@ add_filter( 'img_caption_shortcode', 'commentpress_image_caption_shortcode', 10,
 
 
 if ( ! function_exists( 'commentpress_audio' ) ):
-/** 
+/**
  * Enable audio shortcode
  *
  * @param array $attr Attributes attributed to the shortcode.
@@ -3185,7 +3185,7 @@ function commentpress_audio( $atts, $content = null ) {
         "loop" => '',
         "controls"=> ''
     ), $atts));
-    
+
     return '<audio src="'.$src.'" autoplay="'.$autoplay.'" preload="'.$preload.'" loop="'.$loop.'" controls="'.$controls.'" autobuffer />';
 
 }
@@ -3197,7 +3197,7 @@ endif; // commentpress_audio
 
 
 if ( ! function_exists( 'commentpress_add_commentblock_button' ) ):
-/** 
+/**
  * Add filters for adding our custom TinyMCE button
  *
  * @return void
@@ -3206,18 +3206,18 @@ function commentpress_add_commentblock_button() {
 
 	// only on back-end
 	if ( ! is_admin() ) { return; }
-	
+
 	// don't bother doing this stuff if the current user lacks permissions
 	if ( ! current_user_can( 'edit_posts' ) AND ! current_user_can( 'edit_pages' ) ) {
 		return;
 	}
-	
+
 	// add only if user can edit in Rich-text Editor mode
 	if ( get_user_option( 'rich_editing' ) == 'true' ) {
-	
+
 		add_filter( 'mce_external_plugins', 'commentpress_add_commentblock_tinymce_plugin' );
 		add_filter( 'mce_buttons', 'commentpress_register_commentblock_button' );
-	
+
 	}
 
 }
@@ -3226,17 +3226,17 @@ endif; // commentpress_add_commentblock_button
 
 
 if ( ! function_exists( 'commentpress_register_commentblock_button' ) ):
-/** 
+/**
  * Add filters for adding our custom TinyMCE button
  *
  * @param array $buttons The existing button array
  * @return array $buttons The modified button array
  */
 function commentpress_register_commentblock_button( $buttons ) {
-	
+
 	// add our button to the editor button array
 	array_push( $buttons, '|', 'commentblock' );
-	
+
 	// --<
 	return $buttons;
 
@@ -3246,7 +3246,7 @@ endif; // commentpress_register_commentblock_button
 
 
 if ( ! function_exists( 'commentpress_add_commentblock_tinymce_plugin' ) ):
-/** 
+/**
  * Load the TinyMCE plugin : cp_editor_plugin.js
  *
  * @param array $plugin_array The existing TinyMCE plugin array
@@ -3256,7 +3256,7 @@ function commentpress_add_commentblock_tinymce_plugin( $plugin_array ) {
 
 	// add comment block
 	$plugin_array['commentblock'] = get_template_directory_uri().'/assets/js/tinymce/cp_editor_plugin.js';
-	
+
 	// --<
 	return $plugin_array;
 
@@ -3266,7 +3266,7 @@ endif; // commentpress_add_commentblock_tinymce_plugin
 
 
 if ( ! function_exists( 'commentpress_refresh_mce' ) ):
-/** 
+/**
  * Load the TinyMCE plugin : cp_editor_plugin.js
  *
  * Can this be removed? doesn't seem to affect things...
@@ -3289,7 +3289,7 @@ add_action( 'init', 'commentpress_add_commentblock_button' );
 
 
 if ( ! function_exists( 'commentpress_trap_empty_search' ) ):
-/** 
+/**
  * Trap empty search queries and redirect
  *
  * @todo: this isn't ideal, but works - awaiting core updates
@@ -3300,7 +3300,7 @@ function commentpress_trap_empty_search() {
 
 	// take care of empty searches
 	if ( isset( $_GET['s'] ) AND empty( $_GET['s'] ) ) {
-	
+
 		// send to search page
 		return locate_template( array( 'search.php' ) );
 
@@ -3325,7 +3325,7 @@ if ( version_compare( $wp_version, '3.2', '>=' ) ) {
 
 
 if ( ! function_exists( 'commentpress_amend_password_form' ) ):
-/** 
+/**
  * Adds some style to the password form by adding a class to it
  *
  * @param str $output The existing password form
@@ -3335,7 +3335,7 @@ function commentpress_amend_password_form( $output ) {
 
 	// add css class to form
 	$output = str_replace( '<form ', '<form class="post_password_form" ', $output );
-	
+
 	// add css class to text field
 	$output = str_replace( '<input name="post_password" ', '<input class="post_password_field" name="post_password" ', $output );
 
@@ -3371,7 +3371,7 @@ function commentpress_widgets_init() {
 		'before_title' => '<h3 class="widget-title">',
 		'after_title' => '</h3>',
 	) );
-	
+
 	// widget definitions
 	require( get_template_directory() . '/assets/widgets/widgets.php' );
 
@@ -3411,10 +3411,10 @@ if ( ! function_exists( 'commentpress_license_widget_compat' ) ):
  */
 function commentpress_license_widget_compat() {
 
-	// if the widget is not active, (i.e. the plugin is installed but the widget has not been 
+	// if the widget is not active, (i.e. the plugin is installed but the widget has not been
 	// dragged to a sidebar), then DO NOT display the license in the footer as a default
 	if (!is_active_widget(false, false, 'license-widget', true) ) {
-		remove_action( 'wp_footer', 'license_print_license_html' );			
+		remove_action( 'wp_footer', 'license_print_license_html' );
 	}
 
 }
@@ -3432,7 +3432,7 @@ if ( ! function_exists( 'commentpress_wplicense_compat' ) ):
  * @return void
  */
 function commentpress_wplicense_compat() {
-	
+
 	// let's not have the default footer
 	remove_action( 'wp_footer', 'cc_showLicenseHtml' );
 
@@ -3451,37 +3451,37 @@ if ( ! function_exists( 'commentpress_groupblog_classes' ) ):
  * @return str $groupblog_class The class for the groupblog
  */
 function commentpress_groupblog_classes() {
-	
+
 	// init empty
 	$groupblog_class = '';
-	
+
 	// only add classes when bp-groupblog is active
 	if ( function_exists( 'get_groupblog_group_id' ) ) {
-	
+
 		// init groupblogtype
 		$groupblogtype = 'groupblog';
-		
+
 		// get group blogtype
 		$groupblog_type = groups_get_groupmeta( bp_get_current_group_id(), 'groupblogtype' );
-		
+
 		// did we get one?
 		if ( $groupblog_type ) {
-		
+
 			// add to default
 			$groupblogtype .= ' '.$groupblog_type;
-		
+
 		}
-		
+
 		// complete
 		$groupblog_class = ' class="'.$groupblogtype.'"';
-		
+
 	}
-	
-	
-	
+
+
+
 	// --<
 	return $groupblog_class;
-	
+
 }
 endif; // commentpress_groupblog_classes
 
@@ -3494,86 +3494,86 @@ if ( ! function_exists( 'commentpress_get_post_version_info' ) ):
  * @return void
  */
 function commentpress_get_post_version_info( $post ) {
-	
+
 	// check for newer version
 	$newer_link = '';
-	
+
 	// assume no newer version
 	$newer_id = '';
-	
+
 	// set key
 	$key = '_cp_newer_version';
-	
+
 	// if the custom field already has a value...
 	if ( get_post_meta( $post->ID, $key, true ) !== '' ) {
-	
+
 		// get it
 		$newer_id = get_post_meta( $post->ID, $key, true );
-		
+
 	}
-	
+
 	// if we've got one...
 	if ( $newer_id !== '' ) {
-	
+
 		// get post
 		$newer_post = get_post( $newer_id );
-		
+
 		// is it published?
 		if ( $newer_post->post_status == 'publish' ) {
-	
+
 			// get link
 			$_link = get_permalink( $newer_post->ID );
-			
+
 			// define title
 			$_title = __( 'Newer version', 'commentpress-core' );
-			
+
 			// construct anchor
 			$newer_link = '<a href="'.$_link.'" title="'.$_title.'">'.$_title.' &rarr;</a>';
-		
+
 		}
-	
+
 	}
-	
+
 	// check for older version
 	$older_link = '';
-	
+
 	// get post with this post's ID as their _cp_newer_version meta value
 	$args = array(
-	
+
 		'numberposts' => 1,
 		'meta_key' => '_cp_newer_version',
 		'meta_value' => $post->ID
-	
+
 	);
-	
+
 	// get the array
 	$previous_posts = get_posts( $args );
-	
+
 	// did we get one?
 	if ( is_array( $previous_posts ) AND count( $previous_posts ) == 1 ) {
-	
+
 		// get it
 		$older_post = $previous_posts[0];
-	
+
 		// is it published?
 		if ( $older_post->post_status == 'publish' ) {
-	
+
 			// get link
 			$_link = get_permalink( $older_post->ID );
-			
+
 			// define title
 			$_title = __( 'Older version', 'commentpress-core' );
-			
+
 			// construct anchor
 			$older_link = '<a href="'.$_link.'" title="'.$_title.'">&larr; '.$_title.'</a>';
-		
+
 		}
-	
+
 	}
-	
+
 	// did we get either?
 	if ( $newer_link != '' OR $older_link != '' ) {
-	
+
 		?>
 		<div class="version_info">
 			<ul>
@@ -3582,9 +3582,9 @@ function commentpress_get_post_version_info( $post ) {
 			</ul>
 		</div>
 		<?php
-			
+
 	}
-	
+
 }
 endif; // commentpress_get_post_version_info
 
@@ -3598,41 +3598,41 @@ if ( ! function_exists( 'commentpress_get_post_css_override' ) ):
  * @return str $type_overridden The CSS class
  */
 function commentpress_get_post_css_override( $post_id ) {
-	
+
 	// add a class for overridden page types
 	$type_overridden = '';
-	
+
 	// declare access to globals
 	global $commentpress_core;
 	//print_r(array( 'here' )); die();
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// default to current blog type
 		$type = $commentpress_core->db->option_get( 'cp_blog_type' );
 		//print_r($type); die();
-		
+
 		// set post meta key
 		$key = '_cp_post_type_override';
-		
+
 		// but, if the custom field has a value...
 		if ( get_post_meta( $post_id, $key, true ) !== '' ) {
-		
+
 			// get it
 			$overridden_type = get_post_meta( $post_id, $key, true );
-			
+
 			// is it different to the current blog type?
 			if ( $overridden_type != $type ) {
-			
+
 				$type_overridden = ' overridden_type-'.$overridden_type;
-			
+
 			}
-		
+
 		}
-		
+
 	}
-	
+
 	// --<
 	return $type_overridden;
 
@@ -3649,32 +3649,32 @@ if ( ! function_exists( 'commentpress_get_post_title_visibility' ) ):
  * @return bool $hide True if title is shown, false if hidden
  */
 function commentpress_get_post_title_visibility( $post_id ) {
-	
+
 	// init hide (show by default)
 	$hide = 'show';
-	
+
 	// declare access to globals
 	global $commentpress_core;
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// get global hide
 		$hide = $commentpress_core->db->option_get( 'cp_title_visibility' );;
-		
+
 	}
-	
+
 	// set key
 	$key = '_cp_title_visibility';
-	
+
 	//if the custom field already has a value...
 	if ( get_post_meta( $post_id, $key, true ) != '' ) {
-	
+
 		// get it
 		$hide = get_post_meta( $post_id, $key, true );
-		
+
 	}
-	
+
 	// --<
 	return ( $hide == 'show' ) ? true : false;
 
@@ -3691,32 +3691,32 @@ if ( ! function_exists( 'commentpress_get_post_meta_visibility' ) ):
  * @return bool $hide_meta True if meta is shown, false if hidden
  */
 function commentpress_get_post_meta_visibility( $post_id ) {
-	
+
 	// init hide (hide by default)
 	$hide_meta = 'hide';
-	
+
 	// declare access to globals
 	global $commentpress_core;
-	
+
 	// if we have the plugin enabled...
 	if ( is_object( $commentpress_core ) ) {
-	
+
 		// get global hide_meta
 		$hide_meta = $commentpress_core->db->option_get( 'cp_page_meta_visibility' );;
-		
+
 		// set key
 		$key = '_cp_page_meta_visibility';
-		
+
 		// if the custom field already has a value...
 		if ( get_post_meta( $post_id, $key, true ) != '' ) {
-		
+
 			// override with local value
 			$hide_meta = get_post_meta( $post_id, $key, true );
-			
+
 		}
-		
+
 	}
-	
+
 	// --<
 	return ( $hide_meta == 'show' ) ? true : false;
 
@@ -3725,19 +3725,19 @@ endif; // commentpress_get_post_meta_visibility
 
 
 
-/** 
+/**
  * Temporary fix for WP 3.9
  *
  * @return array $array Existing widgets array
  * @return array $array Modified widgets array
  */
 function commentpress_sidebars_widgets( $array ) {
-	
+
 	// prevent errors in Theme Customizer
 	if ( !is_array( $array ) ) {
 		$array = array();
 	}
-	
+
 	// --<
 	return $array;
 

--- a/commentpress-core/class_commentpress_nav.php
+++ b/commentpress-core/class_commentpress_nav.php
@@ -22,47 +22,47 @@ Class Name
 */
 
 class CommentpressCoreNavigator {
-	
-	
-	
+
+
+
 	/**
 	 * Properties
 	 */
-	
+
 	// parent object reference
 	public $parent_obj;
-	
+
 	// next pages array
 	public $next_pages = array();
-	
+
 	// previous pages array
 	public $previous_pages = array();
-	
+
 	// next posts array
 	public $next_posts = array();
-	
+
 	// previous posts array
 	public $previous_posts = array();
-	
+
 	// page numbers array
 	public $page_numbers = array();
-	
+
 	// menu objects array, when using custom menu
 	public $menu_objects = array();
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Initialises this object
 	 *
 	 * @param object $parent_obj A reference to the parent object
 	 * @return object
 	 */
 	function __construct( $parent_obj ) {
-	
+
 		// store reference to parent
 		$this->parent_obj = $parent_obj;
-	
+
 		// init
 		$this->_init();
 
@@ -70,607 +70,607 @@ class CommentpressCoreNavigator {
 		return $this;
 
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Set up all items associated with this object
 	 *
 	 * @return void
 	 */
 	public function initialise() {
-	
+
 		// if we're navigating pages
 		if ( is_page() ) {
-		
+
 			// init page lists
 			$this->_init_page_lists();
-		
+
 		}
-		
+
 		// if we're navigating posts
 		if( is_single() ) {
-			
+
 			// init posts lists
 			$this->_init_posts_lists();
-			
+
 		}
-		
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * If needed, destroys all items associated with this object
 	 *
 	 * @return void
 	 */
 	public function destroy() {
-	
+
 	}
-	
-	
-	
+
+
+
 //##############################################################################
-	
-	
-	
+
+
+
 	/**
 	 * -------------------------------------------------------------------------
 	 * Public Methods
 	 * -------------------------------------------------------------------------
 	 */
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get next page link
 	 *
 	 * @param bool $with_comments The requested page has comments - default false
 	 * @return object $page_data True if successful, boolean false if not
 	 */
 	public function get_next_page( $with_comments = false ) {
-	
+
 		// do we have any next pages?
 		if ( count( $this->next_pages ) > 0 ) {
-	
+
 			// are we asking for comments?
 			if ( $with_comments ) {
-				
+
 				// loop
 				foreach( $this->next_pages AS $next_page ) {
-				
+
 					// does it have comments?
 					if ( $next_page->comment_count > 0 ) {
-					
+
 						// --<
 						return $next_page;
-					
+
 					}
-				
+
 				}
-				
+
 			} else {
-			
+
 				// --<
 				return $this->next_pages[0];
-			
+
 			}
-			
+
 		}
-		
+
 		// --<
 		return false;
-		
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get previous page link
 	 *
 	 * @param bool $with_comments The requested page has comments - default false
 	 * @return object $page_data True if successful, boolean false if not
 	 */
 	public function get_previous_page( $with_comments = false ) {
-	
+
 		// do we have any previous pages?
 		if ( count( $this->previous_pages ) > 0 ) {
-	
+
 			// are we asking for comments?
 			if ( $with_comments ) {
-			
+
 				// loop
 				foreach( $this->previous_pages AS $previous_page ) {
-				
+
 					// does it have comments?
 					if ( $previous_page->comment_count > 0 ) {
-					
+
 						// --<
 						return $previous_page;
-					
+
 					}
-				
+
 				}
-				
+
 			} else {
-			
+
 				// --<
 				return $this->previous_pages[0];
-			
+
 			}
-			
+
 		}
-		
+
 		// --<
 		return false;
-		
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get next post link
 	 *
 	 * @param bool $with_comments The requested post has comments - default false
 	 * @return object $post_data True if successful, boolean false if not
 	 */
 	public function get_next_post( $with_comments = false ) {
-	
+
 		// do we have any next posts?
 		if ( count( $this->next_posts ) > 0 ) {
-	
+
 			// are we asking for comments?
 			if ( $with_comments ) {
-			
+
 				// loop
 				foreach( $this->next_posts AS $next_post ) {
-				
+
 					// does it have comments?
 					if ( $next_post->comment_count > 0 ) {
-					
+
 						// --<
 						return $next_post;
-					
+
 					}
-				
+
 				}
-				
+
 			} else {
-			
+
 				// --<
 				return $this->next_posts[0];
-			
+
 			}
-		
+
 		}
-		
+
 		// --<
 		return false;
-		
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get previous post link
 	 *
 	 * @param bool $with_comments The requested post has comments - default false
 	 * @return object $post_data True if successful, boolean false if not
 	 */
 	public function get_previous_post( $with_comments = false ) {
-	
+
 		// do we have any previous posts?
 		if ( count( $this->previous_posts ) > 0 ) {
-	
+
 			// are we asking for comments?
 			if ( $with_comments ) {
-			
+
 				// loop
 				foreach( $this->previous_posts AS $previous_post ) {
-				
+
 					// does it have comments?
 					if ( $previous_post->comment_count > 0 ) {
-					
+
 						// --<
 						return $previous_post;
-					
+
 					}
-				
+
 				}
-				
+
 			} else {
-			
+
 				// --<
 				return $this->previous_posts[0];
-			
+
 			}
-			
+
 		}
-		
+
 		// --<
 		return false;
-		
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get first viewable child page
 	 *
 	 * @param int $page_id The page ID
 	 * @return int $first_child The ID of the first child page (or false if not found)
 	 */
 	public function get_first_child( $page_id ) {
-	
+
 		// init to look for published pages
-		$defaults = array( 
+		$defaults = array(
 
 			'post_parent' => $page_id,
-			'post_type' => 'page', 
+			'post_type' => 'page',
 			'numberposts' => -1,
 			'post_status' => 'publish',
 			'orderby' => 'menu_order',
 			'order' => 'ASC'
 
 		);
-					
+
 		// get page children
 		$children = get_children( $defaults );
 		$kids =& $children;
 
 		// do we have any?
 		if ( empty( $kids ) ) {
-		
+
 			// no children
 			return false;
-		
+
 		}
-		
+
 		// we got some...
 		return $this->_get_first_child( $kids );
 
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get list of 'book' pages
 	 *
 	 * @param str $mode Either 'structural' or 'readable'
 	 * @return array $pages All 'book' pages
 	 */
 	public function get_book_pages( $mode = 'readable' ) {
-	
+
 		// init
 		$all_pages = array();
-		
+
 		// do we have a nav menu enabled?
 		if ( has_nav_menu( 'toc' ) ) {
-		
+
 			// parse menu
 			$all_pages = $this->_parse_menu( $mode );
-			
+
 		} else {
-	
+
 			// parse page order
 			$all_pages = $this->_parse_pages( $mode );
-			
+
 		} // end check for custom menu
-		
+
 		//print_r( $all_pages ); die();
-		
+
 		// --<
 		return $all_pages;
 
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get first readable 'book' page
 	 *
 	 * @return int $id The ID of the first page (or false if not found)
 	 */
 	public function get_first_page() {
-	
+
 		// init
 		$id = false;
-	
+
 		// get all pages including chapters
 		$all_pages = $this->get_book_pages( 'structural' );
-		
+
 		// if we have any pages...
 		if ( count( $all_pages ) > 0 ) {
-		
+
 			// get first id
 			$id = $all_pages[0]->ID;
-		
+
 		}
-		
+
 		// --<
 		return $id;
 
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get page number
 	 *
 	 * @param int $page_id The page ID
 	 * @return int $number The number of the page
 	 */
 	public function get_page_number( $page_id ) {
-	
+
 		// init
 		$num = 0;
-		
+
 		// access post
 		global $post;
-		
+
 		// are parent pages viewable?
 		$viewable = ( $this->parent_obj->db->option_get( 'cp_toc_chapter_is_page' ) == '1' ) ? true : false;
-		
+
 		// if they are...
 		if ( $viewable ) {
-		
+
 			// get page number from array
 			$num = $this->_get_page_number( $page_id );
-			
+
 		} else {
-		
+
 			// get id of first viewable child
 			$first_child = $this->get_first_child( $post->ID );
-			
+
 			// if this is a childless page
 			if ( !$first_child ) {
-				
+
 				// get page number from array
 				$num = $this->_get_page_number( $page_id );
-				
+
 			}
-			
+
 		}
-		
+
 		// apply a filter
 		$num = apply_filters( 'cp_nav_page_num', $num );
-		
+
 		// --<
 		return $num;
 
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get page number
 	 *
 	 * @param int $page_id The page ID
 	 * @return int $number The number of the page
 	 */
 	function _get_page_number( $page_id ) {
-	
+
 		// init
 		$num = 0;
-		
+
 		// get from array
 		if ( array_key_exists( $page_id, $this->page_numbers ) ) {
-		
+
 			// get it
 			$num = $this->page_numbers[ $page_id ];
-		
+
 		}
-	
+
 		// --<
 		return $num;
 
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Redirect to child
 	 *
 	 * @return void
 	 */
 	function redirect_to_child() {
-	
+
 		// only on pages
 		if ( !is_page() ) { return; }
-		
+
 		// access post object
 		global $post;
-		
+
 		// do we have one?
 		if ( !is_object( $post ) ) {
-		
+
 			// --<
 			die( 'no post object' );
-			
+
 		}
-		
+
 		// are parent pages viewable?
 		$viewable = ( $this->parent_obj->db->option_get( 'cp_toc_chapter_is_page' ) == '1' ) ? true : false;
-		
+
 		// get id of first child
 		$first_child = $this->get_first_child( $post->ID );
-		
+
 		// our conditions
 		if ( $first_child AND !$viewable ) {
-			
+
 			// get link
 			$redirect = get_permalink( $first_child );
 
 			// do the redirect
-			//header( "HTTP/1.1 301 Moved Permanently" ); 
+			//header( "HTTP/1.1 301 Moved Permanently" );
 			header( "Location: $redirect" );
-		
+
 		}
 
 	}
-	
-	
-	
+
+
+
 //##############################################################################
-	
-	
-	
+
+
+
 	/**
 	 * -------------------------------------------------------------------------
 	 * Private Methods
 	 * -------------------------------------------------------------------------
 	 */
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Object initialisation
 	 *
 	 * @return void
 	 */
 	function _init() {
-	
+
 		/**
 		 * is_page() and is_single() are not yet defined, so we init this object when
 		 * wp_head() is fired - see initialise() above
 		 */
-		
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Set up page list
 	 *
 	 * @return void
 	 */
 	function _init_page_lists() {
-	
+
 		// get all pages
 		$all_pages = $this->get_book_pages( 'readable' );
 
 		// if we have any pages...
 		if ( count( $all_pages ) > 0 ) {
-		
+
 			// generate page numbers
 			$this->_generate_page_numbers( $all_pages );
-			
+
 			// access post object
 			global $post;
-			
+
 			// init the key we want
 			$page_key = false;
-			
+
 			// loop
 			foreach( $all_pages AS $key => $page_obj ) {
-			
+
 				// is it the currently viewed page?
 				if ( $page_obj->ID == $post->ID ) {
-				
+
 					// set page key
 					$page_key = $key;
-				
+
 					// kick out to preserve key
 					break;
-				
+
 				}
-			
+
 			}
-			
+
 			// if we don't get a key...
 			if ( $page_key === false ) {
-			
+
 				// the current page is a chapter and is not a page
 				$this->next_pages = array();
-				
+
 				// --<
 				return;
-			
+
 			}
-			
+
 			// will there be a next array?
 			if ( isset( $all_pages[$key + 1] ) ) {
-			
+
 				// get all subsequent pages
 				$this->next_pages = array_slice( $all_pages, $key + 1 );
-			
+
 			}
-			
+
 			// will there be a previous array?
 			if ( isset( $all_pages[$key - 1] ) ) {
-			
+
 				// get all previous pages
 				$this->previous_pages = array_reverse( array_slice( $all_pages, 0, $key ) );
-				
+
 			}
-			
+
 		} // end have array check
-		
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Set up posts list
 	 *
 	 * @return void
 	 */
 	function _init_posts_lists() {
-	
+
 		// set defaults
 		$defaults = array(
-		
+
 			'numberposts' => -1,
 			'orderby' => 'date'
 
-		); 
-		
+		);
+
 		// get them
 		$all_posts = get_posts( $defaults );
-		
+
 		// if we have any posts...
 		if ( count( $all_posts ) > 0 ) {
-			
+
 			// access post object
 			global $post;
-			
+
 			// loop
 			foreach( $all_posts AS $key => $post_obj ) {
-			
+
 				// is it ours?
 				if ( $post_obj->ID == $post->ID ) {
-				
+
 					// kick out to preserve key
 					break;
-				
+
 				}
-			
+
 			}
-			
+
 			// will there be a next array?
 			if ( isset( $all_posts[$key + 1] ) ) {
-			
+
 				// get all subsequent posts
 				$this->next_posts = array_slice( $all_posts, $key + 1 );
-			
+
 			}
-			
+
 			// will there be a previous array?
 			if ( isset( $all_posts[$key - 1] ) ) {
-			
+
 				// get all previous posts
 				$this->previous_posts = array_reverse( array_slice( $all_posts, 0, $key ) );
-				
+
 			}
-			
+
 		} // end have array check
-		
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Strip out all but lowest level pages
 	 *
 	 * @todo This only works one level deep?
@@ -679,103 +679,103 @@ class CommentpressCoreNavigator {
 	 * @return array $subpages All subpages
 	 */
 	function _filter_chapters( $pages ) {
-	
+
 		// init return
 		$subpages = array();
-		
+
 		// if we have any...
 		if ( count( $pages ) > 0 ) {
-		
+
 			// loop
 			foreach( $pages AS $key => $page_obj ) {
-			
+
 				// init to look for published pages
-				$defaults = array( 
-	
+				$defaults = array(
+
 					'post_parent' => $page_obj->ID,
-					'post_type' => 'page', 
+					'post_type' => 'page',
 					'numberposts' => -1,
 					'post_status' => 'publish'
-	
+
 				);
-							
+
 				// get page children
 				$kids =& get_children( $defaults );
-				
+
 				// do we have any?
 				if ( empty( $kids ) ) {
-				
+
 					// add to our return array
 					$subpages[] = $page_obj;
-				
+
 				}
-			
+
 			}
 
 		} // end have array check
-		
+
 		// --<
 		return $subpages;
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get first published child, however deep
 	 *
 	 * @param array $pages The array of page objects
 	 * @return array $subpages All subpages
 	 */
 	function _get_first_child( $pages ) {
-	
+
 		// if we have any...
 		if ( count( $pages ) > 0 ) {
-		
+
 			// loop
 			foreach( $pages AS $key => $page_obj ) {
-			
+
 				// init to look for published pages
-				$defaults = array( 
-	
+				$defaults = array(
+
 					'post_parent' => $page_obj->ID,
-					'post_type' => 'page', 
+					'post_type' => 'page',
 					'numberposts' => -1,
 					'post_status' => 'publish',
 					'orderby' => 'menu_order',
 					'order' => 'ASC'
 					//sort_column=menu_order,post_title
-	
+
 				);
-							
+
 				// get page children
 				$kids =& get_children( $defaults );
-				
+
 				// do we have any?
 				if ( !empty( $kids ) ) {
-				
+
 					// go deeper
 					return $this->_get_first_child( $kids );
-				
+
 				} else {
-				
+
 					// return first
 					return $page_obj->ID;
-				
+
 				}
-			
+
 			}
 
 		} // end have array check
-		
+
 		// --<
 		return false;
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Generates page numbers
 	 *
 	 * @todo Refine by section, page meta value etc
@@ -784,128 +784,128 @@ class CommentpressCoreNavigator {
 	 * @return void
 	 */
 	function _generate_page_numbers( $pages ) {
-	
+
 		// if we have any...
 		if ( count( $pages ) > 0 ) {
-		
+
 			// init with page 1
 			$num = 1;
-			
+
 			// assume no menu
 			$has_nav_menu = false;
-		
+
 			// if we have a custom menu...
 			if ( has_nav_menu( 'toc' ) ) {
-			
+
 				// override
 				$has_nav_menu = true;
-			
+
 			}
 
 			// loop
 			foreach( $pages AS $page_obj ) {
-			
+
 				// get number format... the way this works in publications is that
 				// only prefaces are numbered with roman numerals. So, we only allow
 				// the first top level page to have the option of roman numerals.
 				// if set, all child pages will be set to roman.
-				
+
 				// once we run out of roman numerals, $num is reset to 1
-				
+
 				// default to arabic
 				$format = 'arabic';
-				
+
 				// set key
 				$key = '_cp_number_format';
-				
+
 				// if the custom field already has a value...
 				if ( get_post_meta( $page_obj->ID, $key, true ) !== '' ) {
-				
+
 					// get it
 					$format = get_post_meta( $page_obj->ID, $key, true );
-			
+
 				} else {
-				
+
 					// if we have a custom menu...
 					if ( $has_nav_menu ) {
-		
+
 						//print_r( $page_obj ); die();
 
 						// get top level menu item
 						$top_menu_item = $this->_get_top_menu_obj( $page_obj );
 						//print_r( $top_menu_item ); //die();
-						
+
 						// since this might not be a WP_POST object...
 						if ( isset( $top_menu_item->object_id ) ) {
-						
+
 							// get ID of top level parent
 							$top_page_id = $top_menu_item->object_id;
-						
+
 							// if the custom field has a value...
 							if ( get_post_meta( $top_page_id, $key, true ) !== '' ) {
-				
+
 								// get it
 								$format = get_post_meta( $top_page_id, $key, true );
-			
+
 							}
-							
+
 						}
-				
+
 					} else {
-	
+
 						// get top level parent
 						$top_page_id = $this->_get_top_parent_id( $page_obj->ID );
-				
+
 						// if the custom field has a value...
 						if ( get_post_meta( $top_page_id, $key, true ) !== '' ) {
-				
+
 							// get it
 							$format = get_post_meta( $top_page_id, $key, true );
-			
+
 						}
-				
+
 					}
-					
+
 				}
-				
+
 				// if it's roman
 				if ( $format == 'roman' ) {
-				
+
 					// convert arabic to roman
 					$this->page_numbers[ $page_obj->ID ] = $this->_number_to_roman( $num );
-				
+
 				} else {
-				
+
 					// if flag not set
 					if ( !isset( $flag ) ) {
-					
+
 						// reset num
 						$num = 1;
-						
+
 						// set flag
 						$flag = true;
-						
+
 					}
-				
+
 					// store roman
 					$this->page_numbers[ $page_obj->ID ] = $num;
-					
+
 				}
-			
+
 				// increment
 				$num++;
-			
+
 			}
-			
+
 			//print_r( $this->page_numbers ); die();
-			
+
 		}
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Utility to remove the Theme My Login page
 	 *
 	 * @todo Pass the array?
@@ -914,98 +914,98 @@ class CommentpressCoreNavigator {
 	 * @return bool $success
 	 */
 	function _filter_theme_my_login_page( $pages ) {
-		
+
 		// init return
 		$clean = array();
-		
+
 		// if we have any...
 		if ( count( $pages ) > 0 ) {
-		
+
 			// loop
 			foreach( $pages AS $page_obj ) {
-			
+
 				// do we have any?
 				if ( !$this->_detect_login_page( $page_obj ) ) {
-				
+
 					// add to our return array
 					$clean[] = $page_obj;
-				
+
 				}
-			
+
 			}
 
 		} // end have array check
-		
+
 		// --<
 		return $clean;
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Utility to detect the Theme My Login page
 	 *
 	 * @param object $page_obj The WordPress page object
 	 * @return boolean $success True if TML page, false otherwise
 	 */
 	function _detect_login_page( $page_obj ) {
-		
+
 		// compat with Theme My Login
-		if( 
-		
-			$page_obj->post_name == 'login' AND 
+		if(
+
+			$page_obj->post_name == 'login' AND
 			$page_obj->post_content == '[theme-my-login]'
-			
+
 		) {
-		
+
 			// --<
 			return true;
-			
+
 		}
-		
+
 		// --<
 		return false;
 
 	}
-	
-	
-	
+
+
+
 	/**
 	 * PHP Roman Numeral Library
-	 * 
+	 *
 	 * Copyright (c) 2008, reusablecode.blogspot.com; some rights reserved.
-	 * 
+	 *
 	 * This work is licensed under the Creative Commons Attribution License. To view
 	 * a copy of this license, visit http://creativecommons.org/licenses/by/3.0/ or
 	 * send a letter to Creative Commons, 559 Nathan Abbott Way, Stanford, California
 	 * 94305, USA.
-	 * 
+	 *
 	 * Utility to convert arabic to roman numerals
 	 *
 	 * @return boolean $result the roman equivalent
 	 */
 	function _number_to_roman( $arabic ) {
-		
+
 		$ones = array("", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX");
 		$tens = array("", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC");
 		$hundreds = array("", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM");
 		$thousands = array("", "M", "MM", "MMM", "MMMM");
-		
+
 		if ( $arabic > 4999 ) {
-		
+
 			// For large numbers (five thousand and above), a bar is placed above a base numeral to indicate multiplication by 1000.
 			// Since it is not possible to illustrate this in plain ASCII, this function will refuse to convert numbers above 4999.
 			die("Cannot represent numbers larger than 4999 in plain ASCII.");
-			
+
 		} elseif ( $arabic == 0 ) {
-		
+
 			// About 725, Bede or one of his colleagues used the letter N, the initial of nullae,
 			// in a table of epacts, all written in Roman numerals, to indicate zero.
 			return "N";
-			
+
 		} else {
-		
+
 			$roman = $thousands[($arabic - fmod($arabic, 1000)) / 1000];
 			$arabic = fmod($arabic, 1000);
 			$roman .= $hundreds[($arabic - fmod($arabic, 100)) / 100];
@@ -1015,172 +1015,172 @@ class CommentpressCoreNavigator {
 			$roman .= $ones[($arabic - fmod($arabic, 1)) / 1];
 			$arabic = fmod($arabic, 1);
 			return $roman;
-			
+
 		}
 
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get top parent page id
 	 *
 	 * @param int $post_id The queried page ID
 	 * @return int $post_id The overridden page ID
 	 */
 	function _get_top_parent_id( $post_id ) {
-		
+
 		// get page data
 		$_page = get_page( $post_id );
-	
+
 		// is the top page?
 		if ( $_page->post_parent == 0 ) {
-	
+
 			// yes -> return the id
 			return $_page->ID;
-	
+
 		} else {
-	
+
 			// no -> recurse upwards
 			return $this->_get_top_parent_id( $_page->post_parent );
-		
+
 		}
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Parse a WP page list
 	 *
 	 * @param str $mode Either 'structural' or 'readable'
 	 * @return array $pages All 'book' pages
 	 */
 	function _parse_pages( $mode ) {
-	
+
 		// init return
 		$pages = array();
-		
+
 		// -----------------------------------------------------------------
 		// construct "book" navigation based on pages
 		// -----------------------------------------------------------------
-			
+
 		// default to no excludes
 		$excludes = '';
-		
+
 		// init excluded array with "special pages"
 		$excluded_pages = $this->parent_obj->db->option_get( 'cp_special_pages' );
-		
+
 		// are we in a BuddyPress scenario?
 		if ( $this->parent_obj->is_buddypress() ) {
-		
+
 			// BuddyPress creates its own registration page at /register and
 			// redirects ordinary WP registration page requests to it. It also
 			// seems to exclude it from wp_list_pages(), see: $cp->display->list_pages()
-		
+
 			// check if registration is allowed
 			if ( '1' == get_option('users_can_register') AND is_main_site() ) {
-			
+
 				// find the registration page by its slug
 				$reg_page = get_page_by_path( 'register' );
-				
+
 				// did we get one?
 				if ( is_object( $reg_page ) AND isset( $reg_page->ID ) ) {
-					
+
 					// yes - exclude it as well
 					$excluded_pages[] = $reg_page->ID;
-				
+
 				}
-			
+
 			}
-		
+
 		}
-		
+
 		// allow plugins to filter
 		$excluded_pages = apply_filters( 'cp_exclude_pages_from_nav', $excluded_pages );
-		
+
 		// are there any?
 		if ( is_array( $excluded_pages ) AND count( $excluded_pages ) > 0 ) {
 
 			// format them for the exclude param
 			$excludes = implode( ',', $excluded_pages );
-			
+
 		}
-		
+
 		// set list pages defaults
 		$defaults = array(
-			'child_of' => 0, 
+			'child_of' => 0,
 			'sort_order' => 'ASC',
-			'sort_column' => 'menu_order, post_title', 
+			'sort_column' => 'menu_order, post_title',
 			'hierarchical' => 1,
-			'exclude' => $excludes, 
+			'exclude' => $excludes,
 			'include' => '',
-			'meta_key' => '', 
+			'meta_key' => '',
 			'meta_value' => '',
-			'authors' => '', 
-			'parent' => -1, 
+			'authors' => '',
+			'parent' => -1,
 			'exclude_tree' => ''
 		);
-		
+
 		// get them
 		$pages = get_pages( $defaults );
-		
+
 		// if we have any pages...
 		if ( count( $pages ) > 0 ) {
 
 			// if chapters are not pages...
 			if ( $this->parent_obj->db->option_get( 'cp_toc_chapter_is_page' ) != '1' ) {
-			
+
 				// do we want all readable pages?
 				if ( $mode == 'readable' ) {
-				
+
 					// filter chapters out
 					$pages = $this->_filter_chapters( $pages );
-				
+
 				}
-				
+
 			}
-			
+
 			// if Theme My Login is present...
 			if ( defined( 'TML_ABSPATH' ) ) {
-			
+
 				// filter its page out
 				$pages = $this->_filter_theme_my_login_page( $pages );
-				
+
 			}
-			
+
 		}
-		
+
 		// --<
 		return $pages;
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Parse a WP menu
 	 *
 	 * @param str $mode Either 'structural' or 'readable'
 	 * @return array $pages All 'book' pages
 	 */
 	function _parse_menu( $mode ) {
-	
+
 		// init return
 		$pages = array();
-		
+
 		// get menu locations
 		$locations = get_nav_menu_locations();
-		
+
 		// check menu locations
 		if ( isset( $locations[ 'toc' ] ) ) {
-			
+
 			// get the menu object
 			$menu = wp_get_nav_menu_object( $locations[ 'toc' ] );
-		
+
 			// default args for reference
 			$args = array(
-			
+
 				'order' => 'ASC',
 				'orderby' => 'menu_order',
 				'post_type' => 'nav_menu_item',
@@ -1189,7 +1189,7 @@ class CommentpressCoreNavigator {
 				'output_key' => 'menu_order',
 				'nopaging' => true,
 				'update_post_term_cache' => false
-			
+
 			);
 
 			// get the menu objects and store for later
@@ -1198,119 +1198,119 @@ class CommentpressCoreNavigator {
 
 			// if we get some
 			if ( $this->menu_objects ) {
-				
+
 				// if chapters are not pages, filter the menu items...
 				if ( $this->parent_obj->db->option_get( 'cp_toc_chapter_is_page' ) != '1' ) {
-	
+
 					// do we want all readable pages?
 					if ( $mode == 'readable' ) {
-		
+
 						// filter chapters out
 						$menu_items = $this->_filter_menu( $this->menu_objects );
-		
+
 					} else {
-					
+
 						// structural - use a copy of the raw menu data
 						$menu_items = $this->menu_objects;
-						
+
 					}
-		
+
 				} else {
-				
+
 					// use a copy of the raw menu data
 					$menu_items = $this->menu_objects;
-				
+
 				}
-				
+
 				// init
 				$pages_to_get = array();
-			
+
 				// convert to array of pages
 				foreach ( $menu_items AS $menu_item ) {
-				
+
 					// is it a WP item?
 					if ( isset( $menu_item->object_id ) ) {
-						
+
 						// init pseudo WP_POST object
 						$pseudo_post = new stdClass;
-						
+
 						// add post ID
 						$pseudo_post->ID = $menu_item->object_id;
-					
+
 						// add menu ID (for filtering below)
 						$pseudo_post->menu_id = $menu_item->ID;
-					
+
 						// add menu item parent ID (for finding parent below)
 						$pseudo_post->menu_item_parent = $menu_item->menu_item_parent;
-					
+
 						// add comment count for possible calls for "next with comments"
 						$pseudo_post->comment_count = $menu_item->comment_count;
-					
+
 						// add to array of WP pages in menu
 						$pages[] = $pseudo_post;
-						
+
 					}
-				
+
 				}
-				
+
 				/*
-				print_r( array( 
-					'menu_items' => $menu_items, 
+				print_r( array(
+					'menu_items' => $menu_items,
 					'pages' => $pages,
 				) ); die();
 				*/
-				
+
 			} // end check for menu items
-			
+
 		} // end check for our menu
-		
+
 		// --<
 		return $pages;
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Strip out all but lowest level menu items
 	 *
 	 * @param array $menu_items An array of menu item objects
 	 * @return array $sub_items All lowest level items
 	 */
 	function _filter_menu( $menu_items ) {
-	
+
 		// init return
 		$sub_items = array();
-		
+
 		// if we have any...
 		if ( count( $menu_items ) > 0 ) {
-		
+
 			// loop
 			foreach( $menu_items AS $key => $menu_obj ) {
-			
+
 				// get item children
 				$kids = $this->_get_menu_item_children( $menu_items, $menu_obj );
-				
+
 				// do we have any?
 				if ( empty( $kids ) ) {
-				
+
 					// add to our return array
 					$sub_items[] = $menu_obj;
-				
+
 				}
-			
+
 			}
 
 		} // end have array check
-		
+
 		// --<
 		return $sub_items;
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Utility to get children of a menu item
 	 *
 	 * @param array $menu_items An array of menu item objects
@@ -1318,118 +1318,118 @@ class CommentpressCoreNavigator {
 	 * @return array $sub_items The menu item children
 	 */
 	function _get_menu_item_children( $menu_items, $menu_obj ) {
-	
+
 		// init return
 		$sub_items = array();
-		
+
 		// if we have any...
 		if ( count( $menu_items ) > 0 ) {
-		
+
 			// loop
 			foreach( $menu_items AS $key => $menu_item ) {
-			
+
 				// is this item a child of the passed in menu object?
 				if ( $menu_item->menu_item_parent == $menu_obj->ID ) {
-				
+
 					// add to our return array
 					$sub_items[] = $menu_item;
-				
+
 				}
-			
+
 			}
 
 		} // end have array check
-		
+
 		// --<
 		return $sub_items;
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Utility to get parent of a menu item
 	 *
 	 * @param obj $menu_obj The menu item object
 	 * @return int $menu_obj The parent menu item
 	 */
 	function _get_menu_item_parent( $menu_obj ) {
-	
+
 		// if we have any...
 		if ( count( $this->menu_objects ) > 0 ) {
-		
+
 			// loop
 			foreach( $this->menu_objects AS $key => $menu_item ) {
-			
+
 				// is this item the first parent of the passed in menu object?
 				if ( $menu_item->ID == $menu_obj->menu_item_parent ) {
-				
+
 					// --<
 					return $menu_item;
-				
+
 				}
-			
+
 			}
 
 		} // end have array check
-		
+
 		// --<
 		return false;
-	
+
 	}
-	
-	
-	
-	/** 
+
+
+
+	/**
 	 * Get top parent menu item
 	 *
 	 * @param object $menu_obj The queried menu object
 	 * @return object $parent_obj The parent object or false if
 	 */
 	function _get_top_menu_obj( $menu_obj ) {
-		
+
 		// there is little point walking the menu tree because menu items can appear
 		// more than once in the menu...
 
 		// HOWEVER: for instances where people do use the menu sensibly, we should
 		// attempt to walk the tree as best we can
-		
+
 		// is this the top item?
 		if ( $menu_obj->menu_item_parent == 0 ) {
-	
+
 			// yes -> return the object
 			return $menu_obj;
-			
+
 		}
-	
+
 		//print_r( $menu_obj ); //die();
 
 		// get parent item
 		$parent_obj = $this->_get_menu_item_parent( $menu_obj );
-	
+
 		//print_r( $parent_obj ); //die();
 
 		// is the top item?
 		if ( $parent_obj->menu_item_parent !== 0 ) {
-	
+
 			// no -> recurse upwards
 			return $this->_get_top_menu_obj( $parent_obj );
-		
+
 		}
-	
+
 		//print_r( $parent_obj ); die();
 
 		// yes -> return the object
 		return $parent_obj;
 
 	}
-	
-	
-	
+
+
+
 //##############################################################################
-	
-	
-	
+
+
+
 } // class ends
 
 


### PR DESCRIPTION
Fixes a couple PHP notices that come up when you have strict standards enabled.

I also included a changeset that trims trailing whitespace d87872e, which you can take or leave as you'd like.
