### PR TITLE
Fix variable naming collision

### DIFF
--- a/commentpress-core/assets/includes/theme/theme-functions.php
+++ b/commentpress-core/assets/includes/theme/theme-functions.php
@@ -960,13 +960,13 @@ function commentpress_page_title() {
 			if ( $ancestors ) {
 				$ancestors = array_reverse( $ancestors );
 
- 				$crumb = array();
+				$crumbs = array();
 
 				foreach ( $ancestors as $crumb ) {
-					$crumb[] = get_the_title( $crumb );
+					$crumbs[] = get_the_title( $crumb );
 				}
 
-				$title .= implode( $sep, $crumb ) . $sep;
+				$title .= implode( $sep, $crumbs ) . $sep;
 			}
 
 		}


### PR DESCRIPTION
Simple fix. This must have been causing a page title to break somewhere, but I fixed it mostly to squash the PHP warning it generated. :smile: 