### PR TITLE
Allow the ajax comment fetching interval to be filtered.

### DIFF
--- a/commentpress-ajax/assets/js/cp-ajax-comments.js
+++ b/commentpress-ajax/assets/js/cp-ajax-comments.js
@@ -218,7 +218,7 @@ CommentPress.ajax.comments = new function() {
 			 */
 
 			// set repeat call
-			CommentpressAjaxSettings.interval = window.setInterval( me.update, 5000 );
+			CommentpressAjaxSettings.interval = window.setInterval( me.update, CommentpressAjaxSettings.cpajax_comment_refresh_interval );
 
 		} else {
 

--- a/commentpress-ajax/cp-ajax-comments.php
+++ b/commentpress-ajax/cp-ajax-comments.php
@@ -100,6 +100,13 @@ function cpajax_add_javascripts() {
 	// get translations array
 	$vars['cpajax_lang'] = cpajax_localise();
 
+	/**
+	 * Comment refresh interval, in milliseconds.
+	 *
+	 * @param int $interval Default is 5000.
+	 */
+	$vars['cpajax_comment_refresh_interval'] = apply_filters( 'cpajax_comment_refresh_interval', 5000 );
+
 	// default to minified scripts
 	$debug_state = commentpress_minified();
 


### PR DESCRIPTION
I've had a problem on a site where a CP page, when visited by a couple users at the same time, was causing large amounts of load on the server, due to the frequent and uncacheable AJAX requests. The default value of 5 seconds seems far too frequent, at least for this use case. I'd like the ability to modify it, which is what this pull request does, though I don't completely understand the way the JS is organized so there may be a better way to set it up than this.